### PR TITLE
Wildcard proxy like API gateway resource at the shared services API gateway

### DIFF
--- a/terraform-shared-services-api-gateway-updater_module/main.tf
+++ b/terraform-shared-services-api-gateway-updater_module/main.tf
@@ -1,47 +1,63 @@
+
 # Reference to the REST API to be updated
 data "aws_api_gateway_rest_api" "rest_api" {
   name = var.shared_services_rest_api_name
 }
 
 # Sample REST API Proxy
-resource "aws_api_gateway_resource" "sample_rest_api" {
+resource "aws_api_gateway_resource" "sample_rest_api_resource" {
   rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
   parent_id   = data.aws_api_gateway_rest_api.rest_api.root_resource_id
   path_part   = "sample_rest_api"
 }
 
+resource "aws_api_gateway_resource" "sample_rest_api_proxy_resource" {
+  rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
+  parent_id   = aws_api_gateway_resource.sample_rest_api_resource.id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "sample_rest_api_proxy_resource_method" {
+  rest_api_id   = data.aws_api_gateway_rest_api.rest_api.id
+  resource_id   = aws_api_gateway_resource.sample_rest_api_proxy_resource.id
+  http_method   = "GET"
+  authorization = "NONE"
+  request_parameters = {
+    "method.request.path.proxy" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "sample_rest_api_proxy_resource_method_integration" {
+  rest_api_id   = data.aws_api_gateway_rest_api.rest_api.id
+  resource_id          = aws_api_gateway_resource.sample_rest_api_proxy_resource.id
+  http_method          = aws_api_gateway_method.sample_rest_api_proxy_resource_method.http_method
+  type                 = "HTTP_PROXY"
+  uri                  = var.sample_rest_api_integration_uri
+  integration_http_method = "GET"
+
+  cache_key_parameters = ["method.request.path.proxy"]
+
+  timeout_milliseconds = 29000
+  request_parameters = {
+    "integration.request.path.proxy" = "method.request.path.proxy"
+  }
+
+}
+
 resource "aws_api_gateway_method" "sample_rest_api_get_method" {
   rest_api_id   = data.aws_api_gateway_rest_api.rest_api.id
-  resource_id   = aws_api_gateway_resource.sample_rest_api.id
-  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.sample_rest_api_resource.id
+  http_method   = "OPTIONS"
   authorization = "NONE"
   request_parameters = {"method.request.header.Authorization" = true}
 }
 
 resource "aws_api_gateway_integration" "sample_rest_api_get_method_integration" {
   rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_resource.sample_rest_api.id
+  resource_id = aws_api_gateway_resource.sample_rest_api_resource.id
   http_method = aws_api_gateway_method.sample_rest_api_get_method.http_method
 
-  type                    = "HTTP"
-  uri                     = var.sample_rest_api_integration_uri
-  integration_http_method = "GET"
-
-  request_parameters = {"integration.request.header.Authorization": "method.request.header.Authorization"}
-}
-
-resource "aws_api_gateway_method_response" "sample_rest_api_get_method_response_200" {
-  rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_resource.sample_rest_api.id
-  http_method = aws_api_gateway_method.sample_rest_api_get_method.http_method
-  status_code = "200"
-}
-
-resource "aws_api_gateway_integration_response" "sample_rest_api_get_method_integration_response" {
-  rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_resource.sample_rest_api.id
-  http_method = aws_api_gateway_method.sample_rest_api_get_method.http_method
-  status_code = aws_api_gateway_method_response.sample_rest_api_get_method_response_200.status_code
+  type        = "MOCK"
 }
 
 

--- a/terraform-shared-services-api-gateway-updater_module/variables.tf
+++ b/terraform-shared-services-api-gateway-updater_module/variables.tf
@@ -13,13 +13,13 @@ variable "shared_services_rest_api_name" {
 variable "sample_rest_api_integration_uri" {
   type = string
   description = "Sample REST API Integration URI"
-  default = "https://p86m7e8qh3.execute-api.us-west-2.amazonaws.com/dev/sips-test-project-level/test-data"
+  default = "https://sample-rest-api-id.execute-api.us-west-2.amazonaws.com/dev/{proxy}"
 }
 
 variable "sample_website_integration_uri" {
   type = string
   description = "Sample Website Integration URI"
-  default = "https://www.google.com"
+  default = "https://www.wikipedia.org"
 }
 
 variable "rest_api_stage" {


### PR DESCRIPTION
## Purpose
This pull request creates a way to have a wildcard proxy like API gateway resource at the shared services API gateway, which is pointing to a project level API gateway.

## Proposed Changes
- [CHANGE] Terraform scripts to create a wildcard proxy resource at shared services API gateway, which is pointing to  the  the project level API gateway
-
## Issues
unity-cs #260
