### PR TITLE
Introduced the lambda authorizer with a list of allowed Cognito user groups as an environment variable and Replaced the OpenAPI template based empty REST API Gateway with a Terraform based REST API Gateway

### DIFF
--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -1,18 +1,33 @@
+# REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.rest_api_name
   description = var.rest_api_description
   endpoint_configuration {
     types = ["REGIONAL"]
   }
-  body = data.template_file.api_template.rendered
 }
 
-# REST API id SSM Param for other resources to modify rest api
+# REST API Gateway rot level GET method
+resource "aws_api_gateway_method" "root_level_get_method" {
+  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
+  resource_id   = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+# REST API Gateway rot level GET method mock integration
+resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
+  rest_api_id          = aws_api_gateway_rest_api.rest_api.id
+  resource_id          = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method          = aws_api_gateway_method.root_level_get_method.http_method
+  type                 = "MOCK"
+}
+
+# REST API ID SSM Param for other resources to modify rest api
 resource "aws_ssm_parameter" "api_gateway_rest_api_id_parameter" {
-  name       = format("/unity/cs/routing/api-gateway/rest-api-id")
+  name       = format("/unity/cs/routing/api-gateway/rest-api-id-2")
   type       = "String"
   value      = aws_api_gateway_rest_api.rest_api.id
-  overwrite  = true
   depends_on = [aws_api_gateway_rest_api.rest_api]
 }
 
@@ -34,7 +49,7 @@ data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_invoke_role_arn" {
   name = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
 }
 
-# Unity CS Common Lambda Authorizer Allowed Cognito Client ID List
+# Unity CS Common Lambda Authorizer Allowed Cognito Client ID List (Command Seperated)
 data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
   name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list
 }
@@ -42,6 +57,11 @@ data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_client_id_lis
 # Unity CS Common Lambda Authorizer Allowed Cognito User Pool ID
 data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
   name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Command Seperated)
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
 }
 
 # Unity CS Common Auth Lambda
@@ -57,23 +77,28 @@ resource "aws_lambda_function" "cs_common_lambda_auth" {
     variables = {
       COGNITO_CLIENT_ID_LIST = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_client_id_list.value
       COGNITO_USER_POOL_ID = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
+      COGNITO_GROUPS_ALLOWED = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_groups_list.value
     }
   }
 }
 
-# OpenAPI Template 
-data "template_file" "api_template" {
-  template = file("${path.module}/unity-project-blank-api-gateway-oas.yaml")
-  vars = {
-    csLambdaAuthorizerUri        = aws_lambda_function.cs_common_lambda_auth.invoke_arn
-    csLambdaAuthorizerInvokeRole = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
-  }
-}
-
-resource "aws_api_gateway_deployment" "api-gateway-deployment" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  stage_name  = var.rest_api_stage
+# Unity CS Common Auth Lambda Authorizer (in API Gateway)
+resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
+  name                              = "Unity_CS_Common_Authorizer"
+  rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
+  authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
+  authorizer_credentials            = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
+  authorizer_result_ttl_in_seconds  = 0
+  identity_source                   = "method.request.header.Authorization"
+depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
 }
 
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+# API Gateway deployment
+resource "aws_api_gateway_deployment" "api-gateway-deployment" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  stage_name  = var.rest_api_stage
+  depends_on = [aws_api_gateway_integration.root_level_get_method_mock_integration]
+}

--- a/terraform-project-api-gateway_module/variables.tf
+++ b/terraform-project-api-gateway_module/variables.tf
@@ -49,13 +49,13 @@ variable "ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn" {
 variable "unity_cs_lambda_authorizer_function_name" {
   type        = string
   description = "Function name of the CS Lambda Authorizer"
-  default     = "unity-cs-common-lambda-auth"
+  default     = "unity-cs-common-lambda-auth-with-group-list"
 }
 
 variable "unity_cs_lambda_authorizer_zip_path" {
   type        = string
   description = "The URL of the CS Lambda Authorizer deployment ZIP file"
-  default     = "https://github.com/unity-sds/unity-cs-auth-lambda/releases/download/1.0.1/unity-cs-lambda-auth-.zip"
+  default     = "https://github.com/unity-sds/unity-cs-auth-lambda/releases/download/1.0.2/unity-cs-lambda-auth-1.0.2.zip"
 }
 
 variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
@@ -68,4 +68,10 @@ variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
   type        = string
   description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Allowed Cognito User Pool ID"
   default     = "/unity/dev/unity-sps-1/api-gateway/functions/cs-lambda-authorizer-cognito-user-pool-id"
+}
+
+variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
+  type        = string
+  description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Allowed Cognito User Groups List"
+  default     = "/unity/dev/unity-sps-1/api-gateway/functions/cs-lambda-authorizer-cognito-user-groups-list"
 }


### PR DESCRIPTION
## Purpose
Introduced the lambda authorizer with a list of allowed Cognito user groups as an environment variable and Replaced the OpenAPI template based empty REST API Gateway with a Terraform based REST API Gateway

## Proposed Changes
feat: Introduced the lambda authorizer with a list of allowed Cognito user groups as an environment variable
chore: Replaced the OpenAPI template based empty REST API Gateway with a Terraform based REST API Gateway, because the OpenAPI template based empty REST API can replace an existing API Gateway

