### PR TITLE
Replaced blank OpenA API based API Gateway template with a completely terraform based API Gateway

### DIFF
--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -7,7 +7,7 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   }
 }
 
-# REST API Gateway rot level GET method
+# REST API Gateway root level GET method
 resource "aws_api_gateway_method" "root_level_get_method" {
   rest_api_id   = aws_api_gateway_rest_api.rest_api.id
   resource_id   = aws_api_gateway_rest_api.rest_api.root_resource_id


### PR DESCRIPTION
## Purpose
- Replace blank OpenA API based API Gateway template with a completely terraform based API Gateway
## Proposed Changes
- [CHANGE] Replaced blank OpenA API based API Gateway template with a completely terraform based API Gateway

