### PR TITLE
Added common lambda authorizer to shared services API Gateway to allow API gateway authentication for shared RESTful APIs

### DIFF
--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -22,7 +22,7 @@ resource "aws_api_gateway_method" "root_level_options_method" {
   authorization = "NONE"
 }
 
-# REST API Gateway rot level GET method mock integration
+# REST API Gateway root level GET method mock integration
 resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
   rest_api_id          = aws_api_gateway_rest_api.rest_api.id
   resource_id          = aws_api_gateway_rest_api.rest_api.root_resource_id

--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_log_group" "cs_common_lambda_auth_log_group" {
 resource "aws_ssm_parameter" "invoke_role_arn" {
   name  = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
   type  = "String"
-  value = aws_iam_role.iam_for_lambda.arn
+  value = aws_iam_role.iam_for_lambda_auth.arn
 }
 
 # Unity CS Common Lambda Authorizer Allowed Cognito Client ID List (Command Seperated)
@@ -72,25 +72,41 @@ data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_l
   name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
 }
 
+# IAM Policy Document for Assume Role
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
-
     principals {
       type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
+      identifiers = ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
     }
-
     actions = ["sts:AssumeRole"]
   }
 }
 
+# IAM Policy Document for Inline Policy
+data "aws_iam_policy_document" "inline_policy" {
+  statement {
+    actions   = ["logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "lambda:InvokeFunction"]
+    resources = ["*"]
+  }
+}
+
+# The Policy for Permission Boundary
 data "aws_iam_policy" "mcp_operator_policy" {
   name = "mcp-tenantOperator-AMI-APIG"
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name               = "iam_for_lambda"
+# IAM Role for Lambda Authorizer
+resource "aws_iam_role" "iam_for_lambda_auth" {
+  name = "iam_for_lambda_auth"
+  inline_policy {
+    name   = "unity-cs-lambda-auth-inline-policy"
+    policy = data.aws_iam_policy_document.inline_policy.json
+  }
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
 }
@@ -99,7 +115,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 resource "aws_lambda_function" "cs_common_lambda_auth" {
   filename      = "ucs-common-lambda-auth.zip"
   function_name = var.unity_cs_lambda_authorizer_function_name
-  role          = aws_iam_role.iam_for_lambda.arn
+  role          = aws_iam_role.iam_for_lambda_auth.arn
   handler       = "index.handler"
   runtime       = "nodejs14.x"
   depends_on = [null_resource.download_lambda_zip]
@@ -118,7 +134,7 @@ resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
   name                              = "Unity_CS_Common_Authorizer"
   rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
   authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
-  authorizer_credentials            = aws_iam_role.iam_for_lambda.arn
+  authorizer_credentials            = aws_iam_role.iam_for_lambda_auth.arn
   authorizer_result_ttl_in_seconds  = 0
   identity_source                   = "method.request.header.Authorization"
 depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -60,19 +60,53 @@ data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_l
   name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
 }
 
-# Unity CS Common Lambda Authorizer Lambda Invoke Role ARN
-data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_invoke_role_arn" {
-  name = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
+# IAM Policy Document for Assume Role
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# IAM Policy Document for Inline Policy
+data "aws_iam_policy_document" "inline_policy" {
+  statement {
+    actions   = ["logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "lambda:InvokeFunction"]
+    resources = ["*"]
+  }
+}
+
+# The Policy for Permission Boundary
+data "aws_iam_policy" "mcp_operator_policy" {
+  name = "mcp-tenantOperator-AMI-APIG"
+}
+
+# IAM Role for Lambda Authorizer
+resource "aws_iam_role" "iam_for_lambda_auth" {
+  name = "iam_for_lambda_auth"
+  inline_policy {
+    name   = "unity-cs-lambda-auth-inline-policy"
+    policy = data.aws_iam_policy_document.inline_policy.json
+  }
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
 }
 
 # Unity CS Common Auth Lambda
 resource "aws_lambda_function" "cs_common_lambda_auth" {
   filename      = "ucs-common-lambda-auth.zip"
   function_name = var.unity_cs_lambda_authorizer_function_name
-  role          = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
+  role          = aws_iam_role.iam_for_lambda_auth.arn
   handler       = "index.handler"
   runtime       = "nodejs14.x"
-  depends_on = [null_resource.download_lambda_zip]
+  depends_on = [null_resource.download_lambda_zip, aws_cloudwatch_log_group.cs_common_lambda_auth_log_group]
 
   environment {
     variables = {
@@ -88,7 +122,7 @@ resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
   name                              = var.unity_cs_api_gateway_authorizer_name
   rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
   authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
-  authorizer_credentials            = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
+  authorizer_credentials            = aws_iam_role.iam_for_lambda_auth.arn
   authorizer_result_ttl_in_seconds  = 0
   identity_source                   = "method.request.header.Authorization"
   depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -15,7 +15,7 @@ resource "aws_api_gateway_method" "root_level_options_method" {
   authorization = "NONE"
 }
 
-# REST API Gateway rot level GET method mock integration
+# REST API Gateway root level GET method mock integration
 resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
   rest_api_id          = aws_api_gateway_rest_api.rest_api.id
   resource_id          = aws_api_gateway_rest_api.rest_api.root_resource_id
@@ -30,6 +30,75 @@ resource "aws_ssm_parameter" "api_gateway_rest_api_id_parameter" {
   value      = aws_api_gateway_rest_api.rest_api.id
   overwrite  = true
   depends_on = [aws_api_gateway_rest_api.rest_api]
+}
+
+# Download the Unity CS Common Auth Lambda deployment zip file
+resource "null_resource" "download_lambda_zip" {
+  provisioner "local-exec" {
+    command = "wget --no-check-certificate ${var.unity_cs_lambda_authorizer_zip_path}  -O ucs-common-lambda-auth.zip"
+  }
+}
+
+# CloudWatch Log Group for Unity CS Common Auth Lambda
+resource "aws_cloudwatch_log_group" "cs_common_lambda_auth_log_group" {
+  name              = "/aws/lambda/${var.unity_cs_lambda_authorizer_function_name}"
+  retention_in_days = 14
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito Client ID List (Command Seperated)
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito User Pool ID
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Command Seperated)
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
+}
+
+# Unity CS Common Lambda Authorizer Lambda Invoke Role ARN
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_invoke_role_arn" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
+}
+
+# Unity CS Common Auth Lambda
+resource "aws_lambda_function" "cs_common_lambda_auth" {
+  filename      = "ucs-common-lambda-auth.zip"
+  function_name = var.unity_cs_lambda_authorizer_function_name
+  role          = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
+  handler       = "index.handler"
+  runtime       = "nodejs14.x"
+  depends_on = [null_resource.download_lambda_zip]
+
+  environment {
+    variables = {
+      COGNITO_CLIENT_ID_LIST = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_client_id_list.value
+      COGNITO_USER_POOL_ID = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
+      COGNITO_GROUPS_ALLOWED = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_groups_list.value
+    }
+  }
+}
+
+# Unity CS Common Auth Lambda Authorizer (in API Gateway)
+resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
+  name                              = var.unity_cs_api_gateway_authorizer_name
+  rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
+  authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
+  authorizer_credentials            = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_invoke_role_arn.value
+  authorizer_result_ttl_in_seconds  = 0
+  identity_source                   = "method.request.header.Authorization"
+  depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
+}
+
+# API Gateway deployment
+resource "aws_api_gateway_deployment" "api-gateway-deployment" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  stage_name  = var.rest_api_stage
+  depends_on = [aws_api_gateway_integration.root_level_get_method_mock_integration]
 }
 
 data "aws_region" "current" {}

--- a/terraform-shared-services-api-gateway_module/variables.tf
+++ b/terraform-shared-services-api-gateway_module/variables.tf
@@ -63,9 +63,3 @@ variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
   description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Allowed Cognito User Groups List"
   default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-cognito-user-groups-list"
 }
-
-variable "ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn" {
-  type        = string
-  description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Invoke Role ARN"
-  default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-invoke-role-arn"
-}

--- a/terraform-shared-services-api-gateway_module/variables.tf
+++ b/terraform-shared-services-api-gateway_module/variables.tf
@@ -27,3 +27,45 @@ variable "rest_api_stage" {
   description = "REST API Stage Name"
   default     = "prod"
 }
+
+variable "unity_cs_api_gateway_authorizer_name" {
+  type        = string
+  description = "Name of the API Gateway Authorizer"
+  default     = "Unity_API_Gateway_Common_Lambda_Authorizer"
+}
+
+variable "unity_cs_lambda_authorizer_function_name" {
+  type        = string
+  description = "Function name of the CS Lambda Authorizer"
+  default     = "ucs-api-gateway-common-lambda-authorizer"
+}
+
+variable "unity_cs_lambda_authorizer_zip_path" {
+  type        = string
+  description = "The URL of the CS Lambda Authorizer deployment ZIP file"
+  default     = "https://github.com/unity-sds/unity-cs-auth-lambda/releases/download/1.0.2/unity-cs-lambda-auth-1.0.2.zip"
+}
+
+variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
+  type        = string
+  description = "SSM Param for Shared Services API Gateway CS Lambda Authorizer Lambda Allowed Cognito Client ID List"
+  default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-cognito-client-id-list"
+}
+
+variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
+  type        = string
+  description = "SSM Param for Shared Services API Gateway CS Lambda Authorizer Lambda Allowed Cognito User Pool ID"
+  default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-cognito-user-pool-id"
+}
+
+variable "ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
+  type        = string
+  description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Allowed Cognito User Groups List"
+  default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-cognito-user-groups-list"
+}
+
+variable "ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn" {
+  type        = string
+  description = "SSM Param for API Gateway CS Lambda Authorizer Lambda Invoke Role ARN"
+  default     = "/unity/shared-services-api-gateway/cs-lambda-authorizer-invoke-role-arn"
+}


### PR DESCRIPTION
## Purpose

Common lambda authorizer to shared services API Gateway to allow API gateway authentication for shared RESTful APIs)

## Proposed Changes
- [ADD]: Common lambda authorizer to shared services API Gateway to allow API gateway authentication for shared RESTful APIs)
- [CHANGE]: Fixed minor typos

