### PR TITLE
Add Cloud Formation Smoke test

### DIFF
--- a/nightly_tests/nightly_tests_ondemand/run.sh
+++ b/nightly_tests/nightly_tests_ondemand/run.sh
@@ -188,7 +188,7 @@ while [ $attempt -le $max_attempts ]; do
 done
 
 # Cloudformation smoke test
-bash smoke_test.sh unity-cs-nightly-management-console > CF_EVENTS.txt
+bash smoke_test.sh "${STACK_NAME}" > CF_EVENTS.txt
 #
 # Run the Selenium test suite against the running Management Console
 #

--- a/nightly_tests/nightly_tests_ondemand/run.sh
+++ b/nightly_tests/nightly_tests_ondemand/run.sh
@@ -124,7 +124,7 @@ bash deploy.sh --stack-name "${STACK_NAME}"
 echo "Sleeping for 360s to give enough time for stack to fully come up..."
 sleep 360  # give enough time for stack to fully come up. TODO: revisit this approach
 
-aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
+# aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
 
 # Get MC URL from SSM (Manamgement Console populates this value)
 export SSM_MC_URL="/unity/cs/management/httpd/loadbalancer-url"
@@ -187,7 +187,8 @@ while [ $attempt -le $max_attempts ]; do
     fi
 done
 
-
+# Cloudformation smoke test
+bash smoke_test.sh unity-cs-nightly-management-console > CF_EVENTS.txt
 #
 # Run the Selenium test suite against the running Management Console
 #
@@ -229,11 +230,11 @@ OUTPUT=$(cat nightly_output.txt)
 GITHUB_LOGS_URL="https://github.com/unity-sds/unity-cs-infra/tree/${GH_BRANCH}/nightly_tests/nightly_tests_ondemand/${LOG_DIR}"
 
 
-cat cloudformation_events.txt |sed 's/\s*},*//g' |sed 's/\s*{//g' |sed 's/\s*\]//' |sed 's/\\"//g' |sed 's/"//g' |sed 's/\\n//g' |sed 's/\\/-/g' |sed 's./.-.g' |sed 's.\\.-.g' |sed 's/\[//g' |sed 's/\]//g' |sed 's/  */ /g' |sed 's/%//g' |grep -v StackName |grep -v StackId |grep -v PhysicalResourceId > CF_EVENTS.txt
- 
-EVENTS=$(cat CF_EVENTS.txt |grep -v ResourceProperties)
-
-echo "$EVENTS" > CF_EVENTS.txt
+# cat cloudformation_events.txt |sed 's/\s*},*//g' |sed 's/\s*{//g' |sed 's/\s*\]//' |sed 's/\\"//g' |sed 's/"//g' |sed 's/\\n//g' |sed 's/\\/-/g' |sed 's./.-.g' |sed 's.\\.-.g' |sed 's/\[//g' |sed 's/\]//g' |sed 's/  */ /g' |sed 's/%//g' |grep -v StackName |grep -v StackId |grep -v PhysicalResourceId > CF_EVENTS.txt
+#  
+# EVENTS=$(cat CF_EVENTS.txt |grep -v ResourceProperties)
+# 
+# echo "$EVENTS" > CF_EVENTS.txt
 
 cat CF_EVENTS.txt
 

--- a/nightly_tests/nightly_tests_ondemand/smoke_test.sh
+++ b/nightly_tests/nightly_tests_ondemand/smoke_test.sh
@@ -1,116 +1,88 @@
 #!/bin/bash
 
 
-# LIST OF AWS RESOURCES CREATED BY CLOUFFORMATION STACK
-#
-# IAM Roles:
-# LambdaExecutionRole
-# InstanceRole
+# Input: CloudFormation stack name
+STACK_NAME="$1"
 
-# IAM Instance Profile:
-# InstanceProfile
+# Check if stack name is provided
+if [ -z "$STACK_NAME" ]; then
+    echo "Usage: $0 <CloudFormation Stack Name>"
+    exit 1
+fi
 
-# Lambda Function:
-# RandomStringLambdaFunction
+# Get all resource IDs from the CloudFormation stack
+resources=$(aws cloudformation list-stack-resources --stack-name "$STACK_NAME" --query "StackResourceSummaries[].[ResourceType,PhysicalResourceId]" --output text)
 
-# SSM Parameters:
-# UnityProjectName
-# UnityVenueName
+echo "Fetching tags for resources in stack '$STACK_NAME'..."
 
-# EC2 Launch Template:
-# ManagmentConsoleLaunchTemplate
+# Loop through resources and fetch tags
+while read -r resourceType resourceId; do
+    case $resourceType in
+        AWS::ElasticLoadBalancingV2::Listener|AWS::Lambda::Function|AWS::CloudFormation::CustomResource|AWS::SSM::Parameter)
+            # Skip fetching tags for these resources
+            continue
+            ;;
+    esac
 
-# AutoScaling Group:
-# DeployerAutoScalingGroup
-
-# Security Groups:
-# ManagementConsoleSecurityGroup
-# ALBSecurityGroup
-
-# Elastic Load Balancing (ELB):
-# MCTargetGroup
-# ApplicationLoadBalancer
-# PublicLoadBalancerListener
-
-
-# SSM parameters used as inputs for the CloudFormation stack
-ssm_parameters_input=(
-  "/unity/testing/nightly/vpc-id"
-  "/unity/testing/nightly/publicsubnet1"
-  "/unity/testing/nightly/publicsubnet2"
-  "/unity/testing/nightly/privatesubnet1"
-  "/unity/testing/nightly/privatesubnet2"
-  "/unity/testing/nightly/instancetype"
-  "/unity/testing/nightly/privilegedpolicyname"
-#  "/unity/testing/nightly/githubtoken"
-  "/unity/testing/nightly/venue"
-  "/unity/testing/nightly/accountname"
-)
-
-# Echo the SSM parameters used for the CloudFormation stack deployment
-echo "SSM Parameters inputted into the CloudFormation stack deployment:"
-
-# Loop through the list of input SSM parameters and echo their names and values
-for param_name in "${ssm_parameters_input[@]}"; do
-  param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
-  
-  if [ $? -eq 0 ]; then
-    echo "Input Parameter Name: ${param_name}"
-    echo "Parameter Value: ${param_value}"
-  else
-    echo "Failed to retrieve value for ${param_name}"
-  fi
-  echo "--------------------------------"
-done
-
-
-
+    echo "Resource: $resourceType, ID: $resourceId"
+    case $resourceType in
+        AWS::EC2::Instance|AWS::EC2::SecurityGroup|AWS::EC2::LaunchTemplate)
+            tags=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$resourceId" --query "Tags[].[Key,Value]" --output text)
+            ;;
+        AWS::IAM::Role)
+            tags=$(aws iam list-role-tags --role-name "$resourceId" --query "Tags[].[Key,Value]" --output text)
+            ;;
+        AWS::IAM::InstanceProfile)
+            # Extract the role name from the instance profile
+            roleName=$(aws iam get-instance-profile --instance-profile-name "$resourceId" --query 'InstanceProfile.Roles[0].RoleName' --output text)
+            if [ "$roleName" != "None" ]; then
+                tags=$(aws iam list-role-tags --role-name "$roleName" --query "Tags[].[Key,Value]" --output text)
+            else
+                tags=""
+            fi
+            ;;
+        AWS::AutoScaling::AutoScalingGroup)
+            # AutoScaling Group names 
+            tags=$(aws autoscaling describe-tags --filters "Name=auto-scaling-group,Values=$resourceId" --query "Tags[].[Key,Value]" --output text)
+            ;;
+        AWS::ElasticLoadBalancingV2::LoadBalancer|AWS::ElasticLoadBalancingV2::TargetGroup)
+            # For ELBv2 (ALB/NLB)
+            tags=$(aws elbv2 describe-tags --resource-arns "$resourceId" --query "TagDescriptions[0].Tags[].[Key,Value]" --output text)
+            ;;
+        *)
+            echo "Skipping resource type $resourceType for tagging details."
+            tags=""
+            ;;
+    esac
+    if [ -n "$tags" ]; then
+        while read -r key value; do
+            echo "  Tag: $key, Value: $value"
+        done <<< "$tags"
+    else
+        echo "  No tags found or unable to retrieve tags for this resource type."
+    fi
+    echo # Newline 
+done <<< "$resources"
 
 
-# SSM Parameters accessed by the CloudFormation stack
-ssm_parameters_accessed=(
-  "/mcp/amis/ubuntu2004-cset"
-)
-
-echo ""
-echo "SSM Parameters accessed by CloudFormation stack:"
-# Loop through the list of accessed parameters and get each parameter
-for param_name in "${ssm_parameters_accessed[@]}"; do
-  param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
-  
-  if [ $? -eq 0 ]; then
-    echo "Accessed Parameter Name: ${param_name}"
-    echo "Parameter Value: ${param_value}"
-  else
-    echo "Failed to retrieve value for ${param_name}"
-  fi
-  echo "--------------------------------"
-done
-
-
-
-
-# SSM Parameters created by the CloudFormation stack
-ssm_parameters_created=(
+# List of SSM Parameter accessed by cloudformation stack
+ssm_parameters=(
   "/unity/core/project"
   "/unity/core/venue"
   "/unity/cs/account/network/vpc_id"
+  "/mcp/amis/ubuntu2004-cset"
 )
 
-echo ""
-echo "SSM Parameters created by CloudFormation stack:"
-# Loop through the list of created parameters and get each parameter
-for param_name in "${ssm_parameters_created[@]}"; do
-  # Attempt to fetch the value of the created parameter
+# Loop through the list and fetch each parameter
+for param_name in "${ssm_parameters[@]}"; do
   param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
   
   # Check if the parameter was successfully retrieved
   if [ $? -eq 0 ]; then
-    echo "Created Parameter Name: ${param_name}"
+    echo "Parameter Name: ${param_name}"
     echo "Parameter Value: ${param_value}"
+    echo "--------------------------------"
   else
-    echo "Failed to retrieve or parameter may not exist yet for ${param_name}"
+    echo "Failed to retrieve value for ${param_name}"
   fi
-  echo "--------------------------------"
 done
-

--- a/nightly_tests/nightly_tests_ondemand/smoke_test.sh
+++ b/nightly_tests/nightly_tests_ondemand/smoke_test.sh
@@ -32,24 +32,85 @@
 # ApplicationLoadBalancer
 # PublicLoadBalancerListener
 
-# List of SSM Parameter accessed by cloudformation stack
-ssm_parameters=(
-  "/unity/core/project"
-  "/unity/core/venue"
-  "/unity/cs/account/network/vpc_id"
+
+# SSM parameters used as inputs for the CloudFormation stack
+ssm_parameters_input=(
+  "/unity/testing/nightly/vpc-id"
+  "/unity/testing/nightly/publicsubnet1"
+  "/unity/testing/nightly/publicsubnet2"
+  "/unity/testing/nightly/privatesubnet1"
+  "/unity/testing/nightly/privatesubnet2"
+  "/unity/testing/nightly/instancetype"
+  "/unity/testing/nightly/privilegedpolicyname"
+#  "/unity/testing/nightly/githubtoken"
+  "/unity/testing/nightly/venue"
+  "/unity/testing/nightly/accountname"
+)
+
+# Echo the SSM parameters used for the CloudFormation stack deployment
+echo "SSM Parameters inputted into the CloudFormation stack deployment:"
+
+# Loop through the list of input SSM parameters and echo their names and values
+for param_name in "${ssm_parameters_input[@]}"; do
+  param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
+  
+  if [ $? -eq 0 ]; then
+    echo "Input Parameter Name: ${param_name}"
+    echo "Parameter Value: ${param_value}"
+  else
+    echo "Failed to retrieve value for ${param_name}"
+  fi
+  echo "--------------------------------"
+done
+
+
+
+
+
+# SSM Parameters accessed by the CloudFormation stack
+ssm_parameters_accessed=(
   "/mcp/amis/ubuntu2004-cset"
 )
 
-# Loop through the list and fetch each parameter
-for param_name in "${ssm_parameters[@]}"; do
+echo ""
+echo "SSM Parameters accessed by CloudFormation stack:"
+# Loop through the list of accessed parameters and get each parameter
+for param_name in "${ssm_parameters_accessed[@]}"; do
+  param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
+  
+  if [ $? -eq 0 ]; then
+    echo "Accessed Parameter Name: ${param_name}"
+    echo "Parameter Value: ${param_value}"
+  else
+    echo "Failed to retrieve value for ${param_name}"
+  fi
+  echo "--------------------------------"
+done
+
+
+
+
+# SSM Parameters created by the CloudFormation stack
+ssm_parameters_created=(
+  "/unity/core/project"
+  "/unity/core/venue"
+  "/unity/cs/account/network/vpc_id"
+)
+
+echo ""
+echo "SSM Parameters created by CloudFormation stack:"
+# Loop through the list of created parameters and get each parameter
+for param_name in "${ssm_parameters_created[@]}"; do
+  # Attempt to fetch the value of the created parameter
   param_value=$(aws ssm get-parameter --name "${param_name}" --query "Parameter.Value" --output text)
   
   # Check if the parameter was successfully retrieved
   if [ $? -eq 0 ]; then
-    echo "Parameter Name: ${param_name}"
+    echo "Created Parameter Name: ${param_name}"
     echo "Parameter Value: ${param_value}"
-    echo "--------------------------------"
   else
-    echo "Failed to retrieve value for ${param_name}"
+    echo "Failed to retrieve or parameter may not exist yet for ${param_name}"
   fi
+  echo "--------------------------------"
 done
+


### PR DESCRIPTION
## Purpose

Added a new script called `smoke_test.sh`. Its job is to check our AWS resources are tagged correctly after we create them with CloudFormation.

## Proposed Changes

- [ADD] `smoke_test.sh` script. This helps us see tags on resources. 

## Issues

No current issues are directly fixed by this change.

## Testing
Ran on bastion host and works
