### PR TITLE
Parameterize metadata_options for EKS node groups

### DIFF
--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -59,14 +59,9 @@ locals {
       min_size                   = ng.min_size != null ? ng.min_size : 1
       max_size                   = ng.max_size != null ? ng.max_size : 10
       desired_size               = ng.desired_size != null ? ng.desired_size : 3
-      ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
       instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
       iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
-      enable_bootstrap_user_data = true
-      pre_bootstrap_user_data    = <<-EOT
-            sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
-        EOT
       create_launch_template     = false
       use_custom_launch_template = true
       launch_template_id         = aws_launch_template.node_group_launch_template.id

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -102,18 +102,6 @@ resource "aws_iam_role" "cluster_iam_role" {
         Principal = {
           Service = "s3.amazonaws.com" # or the appropriate AWS service
         },
-      },
-      {
-        Effect = "Allow",
-        Principal = {
-          Federated = module.eks.oidc_provider_arn
-        },
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Condition = {
-          StringEquals = {
-            module.eks.oidc_provider : "system:serviceaccount:airflow:airflow-worker"
-          }
-        }
       }
     ],
   })

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -67,6 +67,10 @@ locals {
       pre_bootstrap_user_data    = <<-EOT
             sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
         EOT
+      launch_template = {
+        id      = aws_launch_template.node_group_launch_template.id
+        version = "$Latest"
+      }
     }
   }
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -467,7 +467,7 @@ module "eks" {
 }
 
 resource "aws_launch_template" "node_group_launch_template" {
-  image_id = lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
+  image_id = data.aws_ssm_parameter.eks_ami_1_27.value
   name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
   user_data = base64encode(<<EOT
 #!/bin/bash

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -67,6 +67,7 @@ locals {
       pre_bootstrap_user_data    = <<-EOT
             sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
         EOT
+      create_launch_template     = false
       use_custom_launch_template = true
       launch_template_id         = aws_launch_template.node_group_launch_template.id
     }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -67,10 +67,8 @@ locals {
       pre_bootstrap_user_data    = <<-EOT
             sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
         EOT
-      launch_template = {
-        id      = aws_launch_template.node_group_launch_template.id
-        version = "$Latest"
-      }
+      use_custom_launch_template = true
+      launch_template_id         = aws_launch_template.node_group_launch_template.id
     }
   }
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -107,7 +107,7 @@ resource "aws_iam_role" "cluster_iam_role" {
         Principal = {
           Service = "s3.amazonaws.com" # or the appropriate AWS service
         },
-      }
+      },
     ],
   })
 
@@ -477,10 +477,6 @@ set -o xtrace
 /etc/eks/bootstrap.sh ${local.cluster_name}
   EOT
   )
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_put_response_hop_limit = 3
-  }
   tag_specifications {
     resource_type = "instance"
     tags = merge(local.common_tags, {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -472,6 +472,7 @@ resource "aws_launch_template" "node_group_launch_template" {
   user_data = base64encode(<<EOT
 #!/bin/bash
 set -o xtrace
+sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
 /etc/eks/bootstrap.sh ${local.cluster_name}
   EOT
   )

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -434,7 +434,7 @@ module "eks" {
     }
     vpc-cni = {
       most_recent = true
-    }
+    } 
     aws-ebs-csi-driver = {
       most_recent = true
     }
@@ -462,7 +462,7 @@ module "eks" {
 
   eks_managed_node_groups = local.mergednodegroups
 
-  aws_auth_roles                  = var.aws_auth_roles
+  aws_auth_roles = var.aws_auth_roles
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
   tags                            = var.tags
@@ -541,322 +541,322 @@ provider "kubernetes" {
 }
 
 resource "helm_release" "aws-load-balancer-controller" {
-  name       = "aws-load-balancer-controller"
+  name = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
-  chart      = "aws-load-balancer-controller"
-  version    = "1.6.1"
-  namespace  = "kube-system"
+  chart = "aws-load-balancer-controller"
+  version = "1.6.1"
+  namespace = "kube-system"
   set {
-    name  = "clusterName"
+    name = "clusterName"
     value = module.eks.cluster_name
   }
   set {
-    name  = "serviceAccount.create"
+    name = "serviceAccount.create"
     value = "false"
   }
   set {
-    name  = "serviceAccount.name"
+    name = "serviceAccount.name"
     value = "aws-load-balancer-controller"
   }
 
-  depends_on = [module.eks.eks_managed_node_groups]
+  depends_on = [ module.eks.eks_managed_node_groups ]
 }
 
-resource "kubernetes_service_account" "aws-load-balancer-controller-service-account" {
+resource "kubernetes_service_account" "aws-load-balancer-controller-service-account"{
   metadata {
-    name      = "aws-load-balancer-controller"
+    name = "aws-load-balancer-controller"
     namespace = "kube-system"
     annotations = {
-      "eks.amazonaws.com/role-arn" : aws_iam_role.aws-load-balancer-controller-role.arn
+      "eks.amazonaws.com/role-arn": aws_iam_role.aws-load-balancer-controller-role.arn
     }
     labels = {
-      "app.kubernetes.io/component" : "controller"
-      "app.kubernetes.io/name" : "aws-load-balancer-controller"
+      "app.kubernetes.io/component": "controller"
+      "app.kubernetes.io/name": "aws-load-balancer-controller"
     }
   }
 }
 
 locals {
-  openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+  openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://") 
 }
 
-data "aws_iam_policy" "aws-managed-load-balancer-policy" {
-  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
+data "aws_iam_policy" "aws-managed-load-balancer-policy"{
+  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"  
 }
 
 # AwsLoadBalancerController Role and Policy from https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
-resource "aws_iam_role" "aws-load-balancer-controller-role" {
+resource "aws_iam_role" "aws-load-balancer-controller-role"{
   name = "AwsLoadBalancerControllerRole-${local.cluster_name}"
 
   assume_role_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Principal" : {
-          "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
-        },
-        "Action" : "sts:AssumeRoleWithWebIdentity",
-        "Condition" : {
-          "StringEquals" : {
-            "${local.openidc_provider_domain_name}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller",
-            "${local.openidc_provider_domain_name}:aud" : "sts.amazonaws.com"
-          }
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "${local.openidc_provider_domain_name}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller",
+                    "${local.openidc_provider_domain_name}:aud": "sts.amazonaws.com"
+                }
+            }
         }
-      }
     ]
   })
 
-  managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
+  managed_policy_arns = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 }
 
-resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {
-  role       = aws_iam_role.aws-load-balancer-controller-role.name
+resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment"{
+  role = aws_iam_role.aws-load-balancer-controller-role.name
   policy_arn = data.aws_iam_policy.aws-managed-load-balancer-policy.arn
 }
 
-resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
+resource "aws_iam_policy" "aws-load-balancer-controller-policy"{
   name = "AwsLoadBalancerControllerPolicy-${local.cluster_name}"
   policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "iam:CreateServiceLinkedRole"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "StringEquals" : {
-            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:DescribeAccountAttributes",
-          "ec2:DescribeAddresses",
-          "ec2:DescribeAvailabilityZones",
-          "ec2:DescribeInternetGateways",
-          "ec2:DescribeVpcs",
-          "ec2:DescribeVpcPeeringConnections",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeSecurityGroups",
-          "ec2:DescribeInstances",
-          "ec2:DescribeNetworkInterfaces",
-          "ec2:DescribeTags",
-          "ec2:GetCoipPoolUsage",
-          "ec2:DescribeCoipPools",
-          "elasticloadbalancing:DescribeLoadBalancers",
-          "elasticloadbalancing:DescribeLoadBalancerAttributes",
-          "elasticloadbalancing:DescribeListeners",
-          "elasticloadbalancing:DescribeListenerCertificates",
-          "elasticloadbalancing:DescribeSSLPolicies",
-          "elasticloadbalancing:DescribeRules",
-          "elasticloadbalancing:DescribeTargetGroups",
-          "elasticloadbalancing:DescribeTargetGroupAttributes",
-          "elasticloadbalancing:DescribeTargetHealth",
-          "elasticloadbalancing:DescribeTags"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "cognito-idp:DescribeUserPoolClient",
-          "acm:ListCertificates",
-          "acm:DescribeCertificate",
-          "iam:ListServerCertificates",
-          "iam:GetServerCertificate",
-          "waf-regional:GetWebACL",
-          "waf-regional:GetWebACLForResource",
-          "waf-regional:AssociateWebACL",
-          "waf-regional:DisassociateWebACL",
-          "wafv2:GetWebACL",
-          "wafv2:GetWebACLForResource",
-          "wafv2:AssociateWebACL",
-          "wafv2:DisassociateWebACL",
-          "shield:GetSubscriptionState",
-          "shield:DescribeProtection",
-          "shield:CreateProtection",
-          "shield:DeleteProtection"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateSecurityGroup"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateTags"
-        ],
-        "Resource" : "arn:aws:ec2:*:*:security-group/*",
-        "Condition" : {
-          "StringEquals" : {
-            "ec2:CreateAction" : "CreateSecurityGroup"
-          },
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateTags",
-          "ec2:DeleteTags"
-        ],
-        "Resource" : "arn:aws:ec2:*:*:security-group/*",
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:DeleteSecurityGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:CreateLoadBalancer",
-          "elasticloadbalancing:CreateTargetGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:CreateListener",
-          "elasticloadbalancing:DeleteListener",
-          "elasticloadbalancing:CreateRule",
-          "elasticloadbalancing:DeleteRule"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags",
-          "elasticloadbalancing:RemoveTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ],
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags",
-          "elasticloadbalancing:RemoveTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:ModifyLoadBalancerAttributes",
-          "elasticloadbalancing:SetIpAddressType",
-          "elasticloadbalancing:SetSecurityGroups",
-          "elasticloadbalancing:SetSubnets",
-          "elasticloadbalancing:DeleteLoadBalancer",
-          "elasticloadbalancing:ModifyTargetGroup",
-          "elasticloadbalancing:ModifyTargetGroupAttributes",
-          "elasticloadbalancing:DeleteTargetGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "elasticloadbalancing:CreateAction" : [
-              "CreateTargetGroup",
-              "CreateLoadBalancer"
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
             ]
-          },
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
         }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:RegisterTargets",
-          "elasticloadbalancing:DeregisterTargets"
-        ],
-        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:SetWebAcl",
-          "elasticloadbalancing:ModifyListener",
-          "elasticloadbalancing:AddListenerCertificates",
-          "elasticloadbalancing:RemoveListenerCertificates",
-          "elasticloadbalancing:ModifyRule"
-        ],
-        "Resource" : "*"
-      }
     ]
   })
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -473,6 +473,7 @@ set -o xtrace
   EOT
   )
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 3
   }
   tag_specifications {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -467,7 +467,7 @@ module "eks" {
 }
 
 resource "aws_launch_template" "node_group_launch_template" {
-  image_id = "ami-0e3e9697a56f6ba66"
+  image_id = lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
   name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
   user_data = base64encode(<<EOT
 #!/bin/bash

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -68,9 +68,9 @@ locals {
             sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
         EOT
       metadata_options = {
-        "http_endpoint" : lookup(ng.metadata_options, "http_endpoint", null)
-        "http_put_response_hop_limit" : lookup(ng.metadata_options, "http_put_response_hop_limit", null)
-        "http_tokens" : lookup(ng.metadata_options, "http_tokens", null)
+        "http_endpoint" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_endpoint", null) : null
+        "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
+        "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
       }
     }
   }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -68,8 +68,9 @@ locals {
             sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
         EOT
       metadata_options = {
-        "http_endpoint" : "enabled",
-        "http_put_response_hop_limit" : 3,
+        "http_endpoint" : lookup(ng.metadata_options, "http_endpoint", null)
+        "http_put_response_hop_limit" : lookup(ng.metadata_options, "http_put_response_hop_limit", null)
+        "http_tokens" : lookup(ng.metadata_options, "http_tokens", null)
       }
     }
   }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -65,6 +65,7 @@ locals {
       create_launch_template     = false
       use_custom_launch_template = true
       launch_template_id         = aws_launch_template.node_group_launch_template.id
+      version                    = null
     }
   }
 }
@@ -415,8 +416,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "19.16.0"
 
-  cluster_name = local.cluster_name
-  # cluster_version = var.cluster_version
+  cluster_name    = local.cluster_name
+  cluster_version = var.cluster_version
 
   cluster_addons = {
     coredns = {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -467,7 +467,7 @@ module "eks" {
 }
 
 resource "aws_launch_template" "node_group_launch_template" {
-  image_id = data.aws_ssm_parameter.eks_ami_1_27.value
+  image_id = lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
   name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
   user_data = base64encode(<<EOT
 #!/bin/bash

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -59,13 +59,18 @@ locals {
       min_size                   = ng.min_size != null ? ng.min_size : 1
       max_size                   = ng.max_size != null ? ng.max_size : 10
       desired_size               = ng.desired_size != null ? ng.desired_size : 3
+      ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
       instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
       iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
-      create_launch_template     = false
-      use_custom_launch_template = true
-      launch_template_id         = aws_launch_template.node_group_launch_template.id
-      version                    = null
+      enable_bootstrap_user_data = true
+      pre_bootstrap_user_data    = <<-EOT
+            sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
+        EOT
+      metadata_options = {
+        "http_endpoint" : "enabled",
+        "http_put_response_hop_limit" : 3,
+      }
     }
   }
 }
@@ -463,12 +468,11 @@ module "eks" {
 }
 
 resource "aws_launch_template" "node_group_launch_template" {
-  image_id = lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
+  image_id = "ami-0e3e9697a56f6ba66"
   name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
   user_data = base64encode(<<EOT
 #!/bin/bash
 set -o xtrace
-sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
 /etc/eks/bootstrap.sh ${local.cluster_name}
   EOT
   )

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -103,6 +103,18 @@ resource "aws_iam_role" "cluster_iam_role" {
           Service = "s3.amazonaws.com" # or the appropriate AWS service
         },
       },
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = module.eks.oidc_provider_arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            module.eks.oidc_provider : "system:serviceaccount:airflow:airflow-worker"
+          }
+        }
+      }
     ],
   })
 

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -415,8 +415,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "19.16.0"
 
-  cluster_name    = local.cluster_name
-  cluster_version = var.cluster_version
+  cluster_name = local.cluster_name
+  # cluster_version = var.cluster_version
 
   cluster_addons = {
     coredns = {

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -21,6 +21,7 @@ variable "nodegroups" {
     instance_types             = optional(list(string))
     capacity_type              = optional(string)
     enable_bootstrap_user_data = optional(bool)
+    metadata_options           = optional(map(any))
   }))
 
   default = {

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -1,10 +1,10 @@
 variable "tags" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 
 variable "deployment_name" {
-  type = string
+  type    = string
   default = "unity-eks"
 }
 
@@ -23,24 +23,24 @@ variable "nodegroups" {
     enable_bootstrap_user_data = optional(bool)
   }))
 
-  default = { 
-    defaultGroup ={
+  default = {
+    defaultGroup = {
       instance_types = ["m5.xlarge"]
-      min_size = 1
-      max_size = 1
-      desired_size = 1
+      min_size       = 1
+      max_size       = 1
+      desired_size   = 1
     }
   }
 }
 
 variable "aws_auth_roles" {
-    description = "AWS auth roles to associate with the cluster"
-    type = list(object({
-        rolearn = string
-        username = string
-        groups = list(string)
-    })) 
-    default = [ ]
+  description = "AWS auth roles to associate with the cluster"
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
 }
 
 variable "cluster_version" {
@@ -48,20 +48,20 @@ variable "cluster_version" {
   default = "1.27"
 }
 
-variable "project"{
+variable "project" {
   description = "The unity project its installed into"
-  type = string
-  default = "UnknownProject"
+  type        = string
+  default     = "UnknownProject"
 }
 
 variable "venue" {
   description = "The unity venue its installed into"
-  type = string
-  default = "UnknownVenue"
+  type        = string
+  default     = "UnknownVenue"
 }
 
 variable "installprefix" {
   description = "The management console install prefix"
-  type = string
-  default = "UnknownPrefix"
+  type        = string
+  default     = "UnknownPrefix"
 }

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -1,10 +1,10 @@
 variable "tags" {
-  type    = map(string)
+  type = map(string)
   default = {}
 }
 
 variable "deployment_name" {
-  type    = string
+  type = string
   default = "unity-eks"
 }
 
@@ -24,24 +24,24 @@ variable "nodegroups" {
     metadata_options           = optional(map(any))
   }))
 
-  default = {
-    defaultGroup = {
+  default = { 
+    defaultGroup ={
       instance_types = ["m5.xlarge"]
-      min_size       = 1
-      max_size       = 1
-      desired_size   = 1
+      min_size = 1
+      max_size = 1
+      desired_size = 1
     }
   }
 }
 
 variable "aws_auth_roles" {
-  description = "AWS auth roles to associate with the cluster"
-  type = list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-  default = []
+    description = "AWS auth roles to associate with the cluster"
+    type = list(object({
+        rolearn = string
+        username = string
+        groups = list(string)
+    })) 
+    default = [ ]
 }
 
 variable "cluster_version" {
@@ -49,20 +49,20 @@ variable "cluster_version" {
   default = "1.27"
 }
 
-variable "project" {
+variable "project"{
   description = "The unity project its installed into"
-  type        = string
-  default     = "UnknownProject"
+  type = string
+  default = "UnknownProject"
 }
 
 variable "venue" {
   description = "The unity venue its installed into"
-  type        = string
-  default     = "UnknownVenue"
+  type = string
+  default = "UnknownVenue"
 }
 
 variable "installprefix" {
   description = "The management console install prefix"
-  type        = string
-  default     = "UnknownPrefix"
+  type = string
+  default = "UnknownPrefix"
 }


### PR DESCRIPTION
## Purpose

- The `metadata_options` input variable has been integrated into the `terraform-aws-eks_module` Terraform module, facilitating configurations for AWS EKS managed node groups via the `eks-managed-node-group` submodule. This addition provides the flexibility to modify the `http_put_response_hop_limit` parameter within `metadata_options` at deployment. The adjustment of `http_put_response_hop_limit` is particularly crucial for U-SPS deployments where enhanced network layer accessibility is needed for specific operations. One such U-SPS operation involves accessing the instance metadata API from within Docker-in-Docker containers hosted on pods in an EKS node. These containers require a `http_put_response_hop_limit` setting of 3, enabling them to traverse multiple network layers to reach the metadata service successfully.

## Proposed Changes

- [ADD] `metadata_options` as an input variable for the `terraform-unity-eks_module` module.

## Issues

- https://github.com/unity-sds/unity-sps/issues/8

## Testing

- An EKS cluster was manually provisioned in `unity-venue-dev` using `terraform-unity-eks_module`. Following the creation of the EKS cluster, an Airflow-based U-SPS was deployed onto the cluster. DAGs utilizing Docker-in-Docker containers were manually triggered and successfully ran to completion.