### PR TITLE
update deployment of /unity/ci/slack-web-hook-url

### DIFF
--- a/nightly_tests/set_common_ssm_params.sh
+++ b/nightly_tests/set_common_ssm_params.sh
@@ -141,13 +141,13 @@ GITHUB_TOKEN_VAL=$(get_ssm_val "$GITHUB_TOKEN_SSM")
 
 #
 # Create SSM:
-# /unity/cs/githubtoken
+# /unity/ci/slack-web-hook-url
 #
-SLACK_URL_SSM="/unity/ci/slack-web-hook-url"
-SLACK_URL_VAL="empty" # manually gets overridden on CI account
-refresh_ssm_param "${SLACK_URL_SSM}" "${SLACK_URL_VAL}" \
+SLACK_WEB_HOOK_URL_SSM="/unity/ci/slack-web-hook-url"
+populate_if_not_exists_ssm_param "${SLACK_WEB_HOOK_URL_SSM}" \
     "management" "todo" "console" \
-    "unity-all-cs-slackUrl"
+    "unity-all-cs-slackWebHookUrlSsm"
+SLACK_WEB_HOOK_URL_VAL=$(get_ssm_val "$SLACK_WEB_HOOK_URL_SSM")
 
 #
 # Create SSM:

--- a/nightly_tests/uninstall_aws_resources_mc.py
+++ b/nightly_tests/uninstall_aws_resources_mc.py
@@ -37,7 +37,7 @@ def get_ec2_instance_id():
     # Return None if no instance found
     return None
 
-def wait_for_uninstall_complete(log_group_name, log_stream_name, completion_message, check_interval=10, timeout=600):
+def wait_for_uninstall_complete(log_group_name, log_stream_name, completion_message, check_interval=10, timeout=720):
     cw_client = boto3.client('logs', region_name='us-west-2')
     start_time = time.time()
     


### PR DESCRIPTION
## Purpose
- Instead of refreshing  `/unity/ci/slack-web-hook-url` every time the script is ran with `empty`.  We can call the `populate_if_not_exists_ssm_param` function to prompt the user what value the ssm paramater should be if its empty. If its not empty the value does not get changed.
## Proposed Changes
- [CHANGE] `refresh_ssm_param` to `populate_if_not_exists_ssm_param`

