### PR TITLE
don't do role create steps here

### DIFF
--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -157,9 +157,9 @@ if [ -z "$GITHUB_USEREMAIL_VAL" ] ; then
     echo "ERROR: Could not read Github user email from SSM." ; exit 1
 fi
 
-cd ../aws_role_create
-./create_roles_and_policies.sh
-cd ../nightly_tests
+#cd ../aws_role_create
+#./create_roles_and_policies.sh
+#cd ../nightly_tests
 
 #
 # Make sure git is properly setup


### PR DESCRIPTION
## Purpose
Don't do the role creation steps here.  Instead it will happen before this point, as noted in these steps:  https://unity-sds.gitbook.io/docs/developer-docs/common-services/docs/users-guide/deployment/deployment-concepts-and-infrastructure/detailed-breakdown-of-project-onboarding-steps

