### PR TITLE
Further Breakout/Parameterize Inputs to Node Groups for the AWS EKS module

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -1,0 +1,63 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_ssm_parameter" "vpc_id" {
+  name = "/unity/account/network/vpc_id"
+}
+
+data "aws_ssm_parameter" "subnet_list" {
+  name = "/unity/account/network/subnet_list"
+}
+
+#data "aws_ssm_parameter" "cluster_sg" {
+#  name = "/unity/account/eks/cluster_sg"
+#}
+#
+#data "aws_ssm_parameter" "node_sg" {
+#  name = "/unity/account/eks/node_sg"
+#}
+
+#data "aws_ssm_parameter" "eks_iam_node_role" {
+#  name = "/unity/account/eks/eks_iam_node_role"
+#}
+#
+#data "aws_ssm_parameter" "eks_iam_role" {
+#  name = "/unity/account/eks/eks_iam_role"
+#}
+
+data "aws_ssm_parameter" "eks_ami_1_27" {
+  name = "/unity/account/eks/amis/aml2-eks-1-27"
+}
+
+data "aws_ssm_parameter" "eks_ami_1_26" {
+  name = "/unity/account/eks/amis/aml2-eks-1-26"
+}
+
+data "aws_ssm_parameter" "eks_ami_1_25" {
+  name = "/unity/account/eks/amis/aml2-eks-1-25"
+}
+#
+#data "aws_ssm_parameter" "eks_ami_1_24" {
+#  name = "/unity/account/eks/amis/aml2-eks-1-24"
+#}
+
+data "aws_iam_policy" "mcp_operator_policy" {
+  name = "mcp-tenantOperator-AMI-APIG"
+}
+
+data "aws_iam_policy" "datalakekinesis" {
+  name = "DatalakeKinesisPolicy"
+}
+
+data "aws_iam_policy" "mcptools" {
+  name = "McpToolsAccessPolicy"
+}
+
+data "aws_iam_policy" "ebs_csi_policy" {
+  name = "U-CS_Service_Policy"
+}
+
+data "aws_iam_policy" "aws-managed-load-balancer-policy" {
+  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
+}
+
+data "aws_ebs_default_kms_key" "current" {}

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -37,7 +37,6 @@ locals {
           ebs = {
             volume_size           = 100
             volume_type           = "gp2"
-            iops                  = 3000
             throughput            = 150
             encrypted             = true
             kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -37,6 +37,7 @@ locals {
           ebs = {
             volume_size           = 100
             volume_type           = "gp2"
+            throughput            = 150
             encrypted             = true
             kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
             delete_on_termination = true

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -37,7 +37,6 @@ locals {
           ebs = {
             volume_size           = 100
             volume_type           = "gp2"
-            throughput            = 150
             encrypted             = true
             kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
             delete_on_termination = true

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -30,7 +30,6 @@ locals {
         "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
         "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
       }
-      disk_size = ng.disk_size
       block_device_mappings = ng.block_device_mappings != null ? { for device_name, mapping in ng.block_device_mappings :
         device_name => {
           device_name = mapping.device_name

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -1,0 +1,51 @@
+locals {
+  common_tags  = {}
+  cluster_name = var.deployment_name
+  subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
+  #ami = "ami-0e3e9697a56f6ba66"
+  ami_map = {
+    "1.27"    = data.aws_ssm_parameter.eks_ami_1_27.value
+    "1.26"    = data.aws_ssm_parameter.eks_ami_1_26.value
+    "1.25"    = data.aws_ssm_parameter.eks_ami_1_25.value
+    "default" = "ami-0e3e9697a56f6ba66"
+  }
+  #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value
+  mergednodegroups = { for name, ng in var.nodegroups :
+    name => {
+      use_name_prefix            = false
+      create_iam_role            = false
+      min_size                   = ng.min_size != null ? ng.min_size : 1
+      max_size                   = ng.max_size != null ? ng.max_size : 10
+      desired_size               = ng.desired_size != null ? ng.desired_size : 3
+      ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
+      instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+      capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
+      iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
+      enable_bootstrap_user_data = true
+      pre_bootstrap_user_data    = <<-EOT
+            sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
+        EOT
+      metadata_options = {
+        "http_endpoint" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_endpoint", null) : null
+        "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
+        "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
+      }
+      disk_size = ng.disk_size
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp2"
+            iops                  = 3000
+            throughput            = 150
+            encrypted             = true
+            kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+            delete_on_termination = true
+          }
+        }
+      }
+    }
+  }
+  openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+}

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -31,18 +31,18 @@ locals {
         "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
       }
       disk_size = ng.disk_size
-      block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
+      block_device_mappings = ng.block_device_mappings != null ? { for device_name, mapping in ng.block_device_mappings :
+        device_name => {
+          device_name = mapping.device_name
           ebs = {
-            volume_size           = 100
-            volume_type           = "gp2"
-            encrypted             = true
+            volume_size           = mapping.ebs.volume_size
+            volume_type           = mapping.ebs.volume_type
+            encrypted             = mapping.ebs.encrypted
             kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
-            delete_on_termination = true
+            delete_on_termination = mapping.ebs.delete_on_termination
           }
         }
-      }
+      } : null
     }
   }
   openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -42,7 +42,7 @@ locals {
             delete_on_termination = mapping.ebs.delete_on_termination
           }
         }
-      } : null
+      } : {}
     }
   }
   openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -72,7 +72,7 @@ locals {
         "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
         "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
       }
-      ng.disk_size = ng.disk_size
+      disk_size = ng.disk_size
     }
   }
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -72,6 +72,7 @@ locals {
         "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
         "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
       }
+      ng.disk_size = ng.disk_size
     }
   }
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -1,87 +1,3 @@
-data "aws_caller_identity" "current" {}
-
-data "aws_ssm_parameter" "vpc_id" {
-  name = "/unity/account/network/vpc_id"
-}
-
-data "aws_ssm_parameter" "subnet_list" {
-  name = "/unity/account/network/subnet_list"
-}
-
-#data "aws_ssm_parameter" "cluster_sg" {
-#  name = "/unity/account/eks/cluster_sg"
-#}
-#
-#data "aws_ssm_parameter" "node_sg" {
-#  name = "/unity/account/eks/node_sg"
-#}
-
-#data "aws_ssm_parameter" "eks_iam_node_role" {
-#  name = "/unity/account/eks/eks_iam_node_role"
-#}
-#
-#data "aws_ssm_parameter" "eks_iam_role" {
-#  name = "/unity/account/eks/eks_iam_role"
-#}
-
-data "aws_ssm_parameter" "eks_ami_1_27" {
-  name = "/unity/account/eks/amis/aml2-eks-1-27"
-}
-
-data "aws_ssm_parameter" "eks_ami_1_26" {
-  name = "/unity/account/eks/amis/aml2-eks-1-26"
-}
-
-data "aws_ssm_parameter" "eks_ami_1_25" {
-  name = "/unity/account/eks/amis/aml2-eks-1-25"
-}
-#
-#data "aws_ssm_parameter" "eks_ami_1_24" {
-#  name = "/unity/account/eks/amis/aml2-eks-1-24"
-#}
-
-locals {
-  common_tags  = {}
-  cluster_name = var.deployment_name
-  subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
-  #ami = "ami-0e3e9697a56f6ba66"
-  ami_map = {
-    "1.27"    = data.aws_ssm_parameter.eks_ami_1_27.value
-    "1.26"    = data.aws_ssm_parameter.eks_ami_1_26.value
-    "1.25"    = data.aws_ssm_parameter.eks_ami_1_25.value
-    "default" = "ami-0e3e9697a56f6ba66"
-  }
-  #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value
-  mergednodegroups = { for name, ng in var.nodegroups :
-    name => {
-      use_name_prefix            = false
-      create_iam_role            = false
-      min_size                   = ng.min_size != null ? ng.min_size : 1
-      max_size                   = ng.max_size != null ? ng.max_size : 10
-      desired_size               = ng.desired_size != null ? ng.desired_size : 3
-      ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
-      instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-      capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
-      enable_bootstrap_user_data = true
-      pre_bootstrap_user_data    = <<-EOT
-            sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
-        EOT
-      metadata_options = {
-        "http_endpoint" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_endpoint", null) : null
-        "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null
-        "http_tokens" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_tokens", null) : null
-      }
-      disk_size = ng.disk_size
-    }
-  }
-}
-
-
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
-}
-
 resource "aws_iam_role" "cluster_iam_role" {
   name = "${local.cluster_name}-eks-node-role"
 
@@ -116,7 +32,6 @@ resource "aws_iam_role" "cluster_iam_role" {
 
 }
 
-
 resource "aws_iam_role_policy_attachment" "container-reg" {
   role       = aws_iam_role.cluster_iam_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
@@ -146,16 +61,10 @@ resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
   role       = aws_iam_role.cluster_iam_role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
-data "aws_iam_policy" "datalakekinesis" {
-  name = "DatalakeKinesisPolicy"
-}
+
 resource "aws_iam_role_policy_attachment" "kinesis" {
   role       = aws_iam_role.cluster_iam_role.name
   policy_arn = data.aws_iam_policy.datalakekinesis.arn
-}
-
-data "aws_iam_policy" "mcptools" {
-  name = "McpToolsAccessPolicy"
 }
 
 resource "aws_iam_role_policy_attachment" "mcptools" {
@@ -435,7 +344,7 @@ module "eks" {
     }
     vpc-cni = {
       most_recent = true
-    } 
+    }
     aws-ebs-csi-driver = {
       most_recent = true
     }
@@ -463,7 +372,7 @@ module "eks" {
 
   eks_managed_node_groups = local.mergednodegroups
 
-  aws_auth_roles = var.aws_auth_roles
+  aws_auth_roles                  = var.aws_auth_roles
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
   tags                            = var.tags
@@ -511,353 +420,315 @@ resource "aws_ssm_parameter" "eks_subnets" {
   value = join(",", local.subnet_map["private"])
 }
 
-data "aws_iam_policy" "ebs_csi_policy" {
-  name = "U-CS_Service_Policy"
-}
-
-provider "helm" {
-  kubernetes {
-    host                   = module.eks.cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-    }
-  }
-}
-
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-
-}
-
 resource "helm_release" "aws-load-balancer-controller" {
-  name = "aws-load-balancer-controller"
+  name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
-  chart = "aws-load-balancer-controller"
-  version = "1.6.1"
-  namespace = "kube-system"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.6.1"
+  namespace  = "kube-system"
   set {
-    name = "clusterName"
+    name  = "clusterName"
     value = module.eks.cluster_name
   }
   set {
-    name = "serviceAccount.create"
+    name  = "serviceAccount.create"
     value = "false"
   }
   set {
-    name = "serviceAccount.name"
+    name  = "serviceAccount.name"
     value = "aws-load-balancer-controller"
   }
 
-  depends_on = [ module.eks.eks_managed_node_groups ]
+  depends_on = [module.eks.eks_managed_node_groups]
 }
 
-resource "kubernetes_service_account" "aws-load-balancer-controller-service-account"{
+resource "kubernetes_service_account" "aws-load-balancer-controller-service-account" {
   metadata {
-    name = "aws-load-balancer-controller"
+    name      = "aws-load-balancer-controller"
     namespace = "kube-system"
     annotations = {
-      "eks.amazonaws.com/role-arn": aws_iam_role.aws-load-balancer-controller-role.arn
+      "eks.amazonaws.com/role-arn" : aws_iam_role.aws-load-balancer-controller-role.arn
     }
     labels = {
-      "app.kubernetes.io/component": "controller"
-      "app.kubernetes.io/name": "aws-load-balancer-controller"
+      "app.kubernetes.io/component" : "controller"
+      "app.kubernetes.io/name" : "aws-load-balancer-controller"
     }
   }
 }
 
-locals {
-  openidc_provider_domain_name = trimprefix(module.eks.cluster_oidc_issuer_url, "https://") 
-}
-
-data "aws_iam_policy" "aws-managed-load-balancer-policy"{
-  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"  
-}
-
 # AwsLoadBalancerController Role and Policy from https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
-resource "aws_iam_role" "aws-load-balancer-controller-role"{
+resource "aws_iam_role" "aws-load-balancer-controller-role" {
   name = "AwsLoadBalancerControllerRole-${local.cluster_name}"
 
   assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
-            },
-            "Action": "sts:AssumeRoleWithWebIdentity",
-            "Condition": {
-                "StringEquals": {
-                    "${local.openidc_provider_domain_name}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller",
-                    "${local.openidc_provider_domain_name}:aud": "sts.amazonaws.com"
-                }
-            }
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.openidc_provider_domain_name}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller",
+            "${local.openidc_provider_domain_name}:aud" : "sts.amazonaws.com"
+          }
         }
+      }
     ]
   })
 
-  managed_policy_arns = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
+  managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 }
 
-resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment"{
-  role = aws_iam_role.aws-load-balancer-controller-role.name
+resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {
+  role       = aws_iam_role.aws-load-balancer-controller-role.name
   policy_arn = data.aws_iam_policy.aws-managed-load-balancer-policy.arn
 }
 
-resource "aws_iam_policy" "aws-load-balancer-controller-policy"{
+resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
   name = "AwsLoadBalancerControllerPolicy-${local.cluster_name}"
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateServiceLinkedRole"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeVpcPeeringConnections",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeInstances",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeTags",
-                "ec2:GetCoipPoolUsage",
-                "ec2:DescribeCoipPools",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeListenerCertificates",
-                "elasticloadbalancing:DescribeSSLPolicies",
-                "elasticloadbalancing:DescribeRules",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "cognito-idp:DescribeUserPoolClient",
-                "acm:ListCertificates",
-                "acm:DescribeCertificate",
-                "iam:ListServerCertificates",
-                "iam:GetServerCertificate",
-                "waf-regional:GetWebACL",
-                "waf-regional:GetWebACLForResource",
-                "waf-regional:AssociateWebACL",
-                "waf-regional:DisassociateWebACL",
-                "wafv2:GetWebACL",
-                "wafv2:GetWebACLForResource",
-                "wafv2:AssociateWebACL",
-                "wafv2:DisassociateWebACL",
-                "shield:GetSubscriptionState",
-                "shield:DescribeProtection",
-                "shield:CreateProtection",
-                "shield:DeleteProtection"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateSecurityGroup"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": "CreateSecurityGroup"
-                },
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags",
-                "ec2:DeleteTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:DeleteRule"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-            ],
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:SetIpAddressType",
-                "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags"
-            ],
-            "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "elasticloadbalancing:CreateAction": [
-                        "CreateTargetGroup",
-                        "CreateLoadBalancer"
-                    ]
-                },
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets"
-            ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:SetWebAcl",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:AddListenerCertificates",
-                "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
-            ],
-            "Resource": "*"
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
+          }
         }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateSecurityGroup"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : "CreateSecurityGroup"
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "elasticloadbalancing:CreateAction" : [
+              "CreateTargetGroup",
+              "CreateLoadBalancer"
+            ]
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ],
+        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:SetWebAcl",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule"
+        ],
+        "Resource" : "*"
+      }
     ]
   })
 }

--- a/terraform-unity-eks_module/outputs.tf
+++ b/terraform-unity-eks_module/outputs.tf
@@ -1,9 +1,9 @@
 output "eks" {
-    description = "AWS EKS module object to output"
-    value = module.eks
+  description = "AWS EKS module object to output"
+  value       = module.eks
 }
 
-output "cluster_iam_role"{
-    description = "ARN of cluster iam role"
-    value = aws_iam_role.cluster_iam_role.name
+output "cluster_iam_role" {
+  description = "ARN of cluster iam role"
+  value       = aws_iam_role.cluster_iam_role.name
 }

--- a/terraform-unity-eks_module/provider.tf
+++ b/terraform-unity-eks_module/provider.tf
@@ -1,0 +1,25 @@
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      # This requires the awscli to be installed locally where Terraform is executed
+      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    }
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
+
+}

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -23,6 +23,15 @@ variable "nodegroups" {
     enable_bootstrap_user_data = optional(bool)
     metadata_options           = optional(map(any))
     disk_size                  = optional(number)
+    block_device_mappings      = optional(map(object({
+      device_name = string
+      ebs = object({
+        volume_size           = number
+        volume_type           = string
+        encrypted             = bool
+        delete_on_termination = bool
+      })
+    })))
   }))
 
   default = {
@@ -31,6 +40,17 @@ variable "nodegroups" {
       min_size       = 1
       max_size       = 1
       desired_size   = 1
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp2"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
     }
   }
 }

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -22,6 +22,7 @@ variable "nodegroups" {
     capacity_type              = optional(string)
     enable_bootstrap_user_data = optional(bool)
     metadata_options           = optional(map(any))
+    disk_size                  = optional(number)
   }))
 
   default = { 

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -22,7 +22,6 @@ variable "nodegroups" {
     capacity_type              = optional(string)
     enable_bootstrap_user_data = optional(bool)
     metadata_options           = optional(map(any))
-    disk_size                  = optional(number)
     block_device_mappings      = optional(map(object({
       device_name = string
       ebs = object({
@@ -40,17 +39,6 @@ variable "nodegroups" {
       min_size       = 1
       max_size       = 1
       desired_size   = 1
-      block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
-          ebs = {
-            volume_size           = 100
-            volume_type           = "gp2"
-            encrypted             = true
-            delete_on_termination = true
-          }
-        }
-      }
     }
   }
 }

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -1,10 +1,10 @@
 variable "tags" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 
 variable "deployment_name" {
-  type = string
+  type    = string
   default = "unity-eks"
 }
 
@@ -25,24 +25,24 @@ variable "nodegroups" {
     disk_size                  = optional(number)
   }))
 
-  default = { 
-    defaultGroup ={
+  default = {
+    defaultGroup = {
       instance_types = ["m5.xlarge"]
-      min_size = 1
-      max_size = 1
-      desired_size = 1
+      min_size       = 1
+      max_size       = 1
+      desired_size   = 1
     }
   }
 }
 
 variable "aws_auth_roles" {
-    description = "AWS auth roles to associate with the cluster"
-    type = list(object({
-        rolearn = string
-        username = string
-        groups = list(string)
-    })) 
-    default = [ ]
+  description = "AWS auth roles to associate with the cluster"
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
 }
 
 variable "cluster_version" {
@@ -50,20 +50,20 @@ variable "cluster_version" {
   default = "1.27"
 }
 
-variable "project"{
+variable "project" {
   description = "The unity project its installed into"
-  type = string
-  default = "UnknownProject"
+  type        = string
+  default     = "UnknownProject"
 }
 
 variable "venue" {
   description = "The unity venue its installed into"
-  type = string
-  default = "UnknownVenue"
+  type        = string
+  default     = "UnknownVenue"
 }
 
 variable "installprefix" {
   description = "The management console install prefix"
-  type = string
-  default = "UnknownPrefix"
+  type        = string
+  default     = "UnknownPrefix"
 }


### PR DESCRIPTION
## Purpose

- This PR further breakouts and parameterizes inputs for AWS EKS managed node groups via the `eks-managed-node-group` submodule. This provides end users of the `terraform-unity-eks_module` module with finer grain control of their EKS clusters managed node group configuration. For example, U-SPS needed to configure managed node groups with specific EBS volume sizes. This PR specifically breaks out the `block_device_mappings` input of the `eks-managed-node-group` submodule to allow U-SPS and other service areas to configure the required EBS volumes for their EKS clusters.

## Proposed Changes

- [ADD] Further parameterization of inputs for managed node groups
- [CHANGE] Update formatting of Terraform files within the `eks-managed-node-group` submodule to conform to Terraform best practices.

## Issues

- N/A

## Testing

- An EKS cluster was manually provisioned in unity-venue-dev using `terraform-unity-eks_module`. Following the creation of the EKS cluster, an Airflow-based U-SPS was deployed onto the cluster. DAGs were manually triggered and successfully ran to completion.
