### PR TITLE
Updating ssm parameter paths

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -1,11 +1,11 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_ssm_parameter" "vpc_id" {
-  name = "/unity/account/network/vpc_id"
+  name = "/unity/cs/account/network/vpc_id"
 }
 
 data "aws_ssm_parameter" "subnet_list" {
-  name = "/unity/account/network/subnet_list"
+  name = "/unity/cs/account/network/subnet_list"
 }
 
 #data "aws_ssm_parameter" "cluster_sg" {


### PR DESCRIPTION
Updating per unity-sds/unity-sps#14 to new U-CS standards

## Purpose
- Updating ssm parameter paths to match new U-CS naming standards.
## Proposed Changes
- Changing "vpc_id" and "subnet_list" ssm parameter names/paths
## Issues
- unity-sds/unity-sps#14
## Testing
- Tested using "SPS EKS Cluster Provisioning with Terraform" procedure using modified terraform-unity-eks_module version, encountered no issues deploying eks cluster