### PR TITLE
Create SSM parameter for monitoring S3 bucket name

### DIFF
--- a/nightly_tests/destroy_deployment_ssm_params.sh
+++ b/nightly_tests/destroy_deployment_ssm_params.sh
@@ -66,7 +66,7 @@ delete_ssm_param() {
 }
 
 #
-# Create SSM:
+# Delete SSM:
 # /unity/deployment/<PROJECT_NAME>/<VENUE_NAME>/project-name
 #
 PROJECT_NAME_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/project-name"
@@ -74,7 +74,7 @@ PROJECT_NAME_VAL="${PROJECT_NAME}"
 delete_ssm_param "${PROJECT_NAME_SSM}"
 
 #
-# Create SSM:
+# Delete SSM:
 # /unity/deployment/<PROJECT_NAME>/<VENUE_NAME>/venue-name
 #
 VENUE_NAME_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/venue-name"
@@ -82,9 +82,17 @@ VENUE_NAME_VAL="${VENUE_NAME}"
 delete_ssm_param "${VENUE_NAME_SSM}"
 
 #
-# Create SSM:
+# Delete SSM:
 # /unity/deployment/<PROJECT_NAME>/<VENUE_NAME>/status
 #
 DEPLOYMENT_STATUS_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/status"
 DEPLOYMENT_STATUS_VAL="deploying"
 delete_ssm_param "${DEPLOYMENT_STATUS_SSM}"
+
+# Delete SSM:
+# /unity/${project}/${venue}/cs/monitoring/s3/bucketName
+#
+S3_HEALTH_CHECK_NAME_SSM="/unity/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
+S3_HEALTH_CHECK_NAME_VAL="${PROJECT_NAME}-${VENUE_NAME}-health-check"
+
+delete_ssm_param "${S3_HEALTH_CHECK_NAME_SSM}"

--- a/nightly_tests/destroy_deployment_ssm_params.sh
+++ b/nightly_tests/destroy_deployment_ssm_params.sh
@@ -92,7 +92,7 @@ delete_ssm_param "${DEPLOYMENT_STATUS_SSM}"
 # Delete SSM:
 # /unity/${project}/${venue}/cs/monitoring/s3/bucketName
 #
-S3_HEALTH_CHECK_NAME_SSM="/unity/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
+S3_HEALTH_CHECK_NAME_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
 S3_HEALTH_CHECK_NAME_VAL="${PROJECT_NAME}-${VENUE_NAME}-health-check"
 
 delete_ssm_param "${S3_HEALTH_CHECK_NAME_SSM}"

--- a/nightly_tests/set_deployment_ssm_params.sh
+++ b/nightly_tests/set_deployment_ssm_params.sh
@@ -141,7 +141,7 @@ refresh_ssm_param "${DEPLOYMENT_STATUS_SSM}" "${DEPLOYMENT_STATUS_VAL}" "managem
 # Create SSM:
 # /unity/${project}/${venue}/cs/monitoring/s3/bucketName
 #
-S3_HEALTH_CHECK_NAME_SSM="/unity/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
+S3_HEALTH_CHECK_NAME_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
 S3_HEALTH_CHECK_NAME_VAL="${PROJECT_NAME}-${VENUE_NAME}-health-check"
 refresh_ssm_param "${S3_HEALTH_CHECK_NAME_SSM}" "${S3_HEALTH_CHECK_NAME_VAL}" "management" "todo" "console" \
 "${PROJECT_NAME}-${VENUE_NAME}-cs-management-S3HealthCheckBucketNameSsm"

--- a/nightly_tests/set_deployment_ssm_params.sh
+++ b/nightly_tests/set_deployment_ssm_params.sh
@@ -137,3 +137,11 @@ DEPLOYMENT_STATUS_SSM="/unity/deployment/${PROJECT_NAME}/${VENUE_NAME}/status"
 DEPLOYMENT_STATUS_VAL="deploying"
 refresh_ssm_param "${DEPLOYMENT_STATUS_SSM}" "${DEPLOYMENT_STATUS_VAL}" "management" "todo" "console" \
 "${PROJECT_NAME}-${VENUE_NAME}-cs-management-deploymentStatusSsm"
+
+# Create SSM:
+# /unity/${project}/${venue}/cs/monitoring/s3/bucketName
+#
+S3_HEALTH_CHECK_NAME_SSM="/unity/${PROJECT_NAME}/${VENUE_NAME}/cs/monitoring/s3/bucketName"
+S3_HEALTH_CHECK_NAME_VAL="${PROJECT_NAME}-${VENUE_NAME}-health-check"
+refresh_ssm_param "${S3_HEALTH_CHECK_NAME_SSM}" "${S3_HEALTH_CHECK_NAME_VAL}" "management" "todo" "console" \
+"${PROJECT_NAME}-${VENUE_NAME}-cs-management-S3HealthCheckBucketNameSsm"


### PR DESCRIPTION
## Purpose
- When the Management Console is deployed, a SSM parameter is created (and populated) that represents the S3 bucket where the health check JSON reports are to be stored.
- `/unity/${project}/${venue}/cs/monitoring/s3/bucketName`
## Proposed Changes
- Add creation of SSM param in `set_deployment_ssm_params.sh` 
- Add deletion of SSM param in `destroy_deployment_ssm_params.sh`
## Issues
- close unity-sds/unity-cs#370

