### PR TITLE
Further cleanup of /unity/core/venue|project SSM Needed #399

### DIFF
--- a/nightly_tests/smoke_test.sh
+++ b/nightly_tests/smoke_test.sh
@@ -91,8 +91,6 @@ done <<< "$resources"
 # List of SSM Parameter accessed  and created by cloudformation stack
 # TODO Dynamically check variables
 ssm_parameters=(
-  "/unity/core/project"
-  "/unity/core/venue"
   "/unity/cs/account/network/vpc_id"
   "/mcp/amis/ubuntu2004-cset"
   "/unity/testing/nightly/vpc-id"

--- a/unity-cloud-env/main.tf
+++ b/unity-cloud-env/main.tf
@@ -1,27 +1,12 @@
 variable "default_tags" {
   default = {
     Owner   = "Unity CS"
-    Project = "Unity CS"
   }
   description = "Default Tags"
   type        = map(string)
 }
 
 data "aws_caller_identity" "current" {}
-
-resource "aws_ssm_parameter" "unity-venue" {
-  name  = "/unity/core/venue"
-  type  = "String"
-  value = var.venue
-  overwrite = true
-}
-
-resource "aws_ssm_parameter" "unity-project" {
-  name  = "/unity/core/project"
-  type  = "String"
-  value = var.project
-  overwrite = true
-}
 
 resource "aws_ssm_parameter" "eks-instance-role" {
   name = "/unity/account/roles/eksInstanceRoleArn"


### PR DESCRIPTION
Removes creation of `/unity/core/venue` and `/unity/core/project` SSM params from terraform script. Also removes checking for these params from run.sh.