### PR TITLE
fixes api gw name #408

### DIFF
--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -1,7 +1,7 @@
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
-  name        = var.rest_api_name
-  description = var.rest_api_description
+  name        = "unity-${var.project}-${var.venue}-rest-api-gateway"
+  description = "Unity ${var.project}-${var.venue} Project REST API Gateway"
   endpoint_configuration {
     types = ["REGIONAL"]
   }

--- a/terraform-project-api-gateway_module/variables.tf
+++ b/terraform-project-api-gateway_module/variables.tf
@@ -13,7 +13,7 @@ variable "deployment_name" {
   description = "The deployment name"
   type        = string
 }
-variable "project"{
+variable "project" {
   description = "The unity project its installed into"
   type = string
   default = "UnknownProject"
@@ -36,18 +36,6 @@ variable "installprefix" {
   description = "The management console install prefix"
   type = string
   default = "UnknownPrefix"
-}
-
-variable "rest_api_name" {
-  type        = string
-  description = "REST API Name"
-  default     = "Unity SampleProject-Dev Project REST API Gateway"
-}
-
-variable "rest_api_description" {
-  type        = string
-  description = "REST API Description"
-  default     = "Unity Unity-SampleProject-Dev Project REST API Gateway"
 }
 
 variable "rest_api_stage" {


### PR DESCRIPTION
## Purpose
- Gets rid of two terraform variables that lack project/venue name-spacing, and replaces with dynamic values.
## Proposed Changes
- Gets rid of two terraform variables that lack project/venue name-spacing, and replaces with dynamic values.
## Issues
- https://github.com/unity-sds/unity-cs/issues/408
## Testing

