### PR TITLE
Upgrade EKS AMIs to MCP 1.29

### DIFF
--- a/nightly_tests/set_common_ssm_params.sh
+++ b/nightly_tests/set_common_ssm_params.sh
@@ -216,10 +216,17 @@ refresh_ssm_param "${EKS_AMI_26_SSM}" "${EKS_AMI_26_VAL}" "processing" "na" "vpc
 
 #
 # SSM:  /unity/account/eks/amis/aml2-eks-1-27
-# 
+#
 EKS_AMI_27_SSM="/unity/account/eks/amis/aml2-eks-1-27"
 EKS_AMI_27_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-27")
 refresh_ssm_param "${EKS_AMI_27_SSM}" "${EKS_AMI_27_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks127Ssm"
+
+#
+# SSM:  /unity/account/eks/amis/aml2-eks-1-29
+#
+EKS_AMI_29_SSM="/unity/account/eks/amis/aml2-eks-1-29"
+EKS_AMI_29_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-29")
+refresh_ssm_param "${EKS_AMI_29_SSM}" "${EKS_AMI_29_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks129Ssm"
 
 #
 # SSM:  /unity/shared-services/account

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -24,6 +24,10 @@ data "aws_ssm_parameter" "subnet_list" {
 #  name = "/unity/account/eks/eks_iam_role"
 #}
 
+data "aws_ssm_parameter" "eks_ami_1_29" {
+  name = "/unity/account/eks/amis/aml2-eks-1-29"
+}
+
 data "aws_ssm_parameter" "eks_ami_1_27" {
   name = "/unity/account/eks/amis/aml2-eks-1-27"
 }

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -4,10 +4,11 @@ locals {
   subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
   #ami = "ami-0e3e9697a56f6ba66"
   ami_map = {
+    "1.29"    = data.aws_ssm_parameter.eks_ami_1_29.value
     "1.27"    = data.aws_ssm_parameter.eks_ami_1_27.value
     "1.26"    = data.aws_ssm_parameter.eks_ami_1_26.value
     "1.25"    = data.aws_ssm_parameter.eks_ami_1_25.value
-    "default" = "ami-0e3e9697a56f6ba66"
+    "default" = "ami-0f4319b351ce92b6e"
   }
   #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value
   mergednodegroups = { for name, ng in var.nodegroups :

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -55,7 +55,7 @@ variable "aws_auth_roles" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.27"
+  default = "1.29"
 }
 
 variable "project" {


### PR DESCRIPTION
## Purpose
- This PR adds the option to use the latest MCP AMI (EKS 1.29)

## Proposed Changes
- [ADD] SSM parameter key /unity/account/eks/amis/aml2-eks-1-29 and related variables

## Issues
- [Links to relevant issues](https://github.com/unity-sds/unity-sps/issues/159)

## Testing
-  Was able to deploy an EKS cluster and verified the AMIs are the proper version