### PR TITLE
Move cloudformation 443

### DIFF
--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -1,0 +1,735 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Deploy a load balanced EC2 instance into an existing VPC for deployment of Unity Management Console
+
+Metadata:
+  QuickStartDocumentation:
+    EntrypointName: Launch into an existing VPC
+
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Unity Project Setup"
+        Parameters:
+          - Project
+          - Venue
+          - GithubToken
+          - MCVersion
+      - Label:
+          default: Network configuration
+        Parameters:
+          - VPCID
+          - PublicSubnetID1
+          - PublicSubnetID2
+          - PrivateSubnetID1
+          - PrivateSubnetID2
+          - Port
+      - Label:
+          default: "Amazon EC2 Configuration"
+        Parameters:
+          - InstanceType
+      - Label:
+          default: "MCP Configuration"
+        Parameters:
+          - PrivilegedPolicyName
+          - AMI
+    ParameterLabels:
+      VPCID:
+        default: VPC ID
+      PublicSubnetID1:
+        default: Public subnet ID 1
+      PublicSubnetID2:
+        default: Public subnet ID 2
+      PrivateSubnetID1:
+        default: Private subnet ID 1
+      PrivateSubnetID2:
+        default: Private subnet ID 2
+      InstanceType:
+        default: EC2 instance type
+      PrivilegedPolicyName:
+        default: Privileged (admin-level) IAM policy name
+      GithubToken:
+        default: Github token with repo:read access.
+      MCVersion:
+        default: latest
+      Venue:
+        default: Name of the venue being setup
+      Project:
+        default: Name of the project that owns and operates the account
+      Port:
+        default: Port used for the Managmente Console ALB
+      AMI:
+        default: AMI id used for deploying the Management Console
+
+Parameters:
+  VPCID:
+    Description: ID of your existing VPC (e.g., vpc-0343606e).
+    Type: AWS::EC2::VPC::Id
+
+  PublicSubnetID1:
+    Description: ID of the public subnet 1 in an Availability Zone of your existing VPC (e.g., subnet-fe9a8b32).
+    Type: AWS::EC2::Subnet::Id
+
+  PublicSubnetID2:
+    Description: ID of the public subnet 2 in an Availability Zone of your existing VPC (e.g., subnet-fe9a8b32).
+    Type: AWS::EC2::Subnet::Id
+
+  PrivateSubnetID1:
+    Description: ID of the private subnet 1 in an Availability Zone of your existing VPC (e.g., subnet-fe9a8b32).
+    Type: AWS::EC2::Subnet::Id
+
+  PrivateSubnetID2:
+    Description: ID of the private subnet 2 in an Availability Zone of your existing VPC (e.g., subnet-fe9a8b32).
+    Type: AWS::EC2::Subnet::Id
+
+  InstanceType:
+    Description: EC2 instance type
+    Type: String
+    AllowedValues:
+      - m7i.xlarge
+      - m6i.xlarge
+      - m6in.xlarge
+      - m5.xlarge
+      - m5n.xlarge
+      - m5zn.xlarge
+      - c6i.xlarge
+      - c5.xlarge
+    Default: c6i.xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+
+  PrivilegedPolicyName:
+    Description: Name of an existing IAM policy which allows privileged access to AWS services.
+    Type: String
+    Default: mcp-tenantOperator-AMI-APIG
+
+  GithubToken:
+    Description: Github PAT with repo:read access. Used to clone repositories from https://github.com/unity-sds
+    Type: String
+    NoEcho: true
+
+  MCVersion:
+    Description: Management Console Version
+    Type: String
+    Default: latest
+    ConstraintDescription: The version of unity-sds/unity-management-console to install.
+
+  Venue:
+    Description: e.g. Dev, Test, Ops. See https://unity-sds.gitbook.io/docs/architecture/deployments-projects-and-venues
+    Type: String
+    Default: Dev
+
+  Project:
+    Description: e.g. unity, SBG, Mars 2020. See https://unity-sds.gitbook.io/docs/architecture/deployments-projects-and-venues
+    Type: String
+    Default: unity
+
+  Port:
+    Description: Port that the management console will be served on
+    Type: Number
+    Default: 8080
+    MinValue: 1
+    MaxValue: 65535
+
+  AMI:
+    Default: /mcp/amis/ubuntu2004-cset
+    Description: Name of SSM parameter containing Latest Ubuntu MCP AMI ID
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+
+Conditions:
+  IsLatestMCVersion:
+    Fn::Equals:
+      - !Ref MCVersion
+      - latest
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: allowLambdaLogging
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:*
+                Resource: "*"
+      PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"
+
+  RandomStringLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.8
+      Role: !GetAtt LambdaExecutionRole.Arn
+      MemorySize: 128
+      Timeout: 20
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity RandomStringLambdaFunction
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+      Code:
+        ZipFile: |
+          import cfnresponse
+          import logging
+          import random
+          import string
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+
+          def get_random_string(event, context):
+              random_string = "".join(
+                  random.choice(string.ascii_lowercase + string.digits)
+                  for i in range(int(event["ResourceProperties"]["Length"]))
+              )
+              logger.info("Random string generated: %s", random_string)
+              return random_string
+
+
+          def handler(event, context):
+              response_data = dict()
+              try:
+                  response_data["RandomString"] = get_random_string(event, context)
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data)
+              except Exception as e:
+                  logger.error(e)
+                  cfnresponse.send(event, context, cfnresponse.FAILED, response_data)
+
+  RandomStringResource:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      Length: 5
+      ServiceToken: !GetAtt RandomStringLambdaFunction.Arn
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
+
+        # TODO: need to generalize for JPL, MCP and normal AWS accounts; currently these are specific to MCP
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DatalakeKinesisPolicy"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/McpToolsAccessPolicy"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy_Ondemand"
+      PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity Management Console Instance Role
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref InstanceRole
+
+  ManagmentConsoleLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Metadata:
+      AWS::CloudFormation::Init:
+        configSets:
+          deployer_install:
+            - install_cfn
+            - install_deployer_tools
+            - install_cloudwatch_agent
+            - deploy_management_console
+        install_cfn:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+              group: root
+              mode: "000400"
+              owner: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.ManagmentConsoleLaunchTemplate.Metadata.AWS::CloudFormation::Init
+                action=/usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource ManagmentConsoleLaunchTemplate --configsets deployer_install --region ${AWS::Region} --url https://stackbuilder.amazonaws.com
+                runas=root
+              group: root
+              mode: "000400"
+              owner: root
+            /lib/systemd/system/cfn-hup.service:
+              content: !Sub |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/usr/local/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+          services:
+            systemd:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files:
+                  - /etc/cfn/cfn-hup.conf
+                  - /etc/cfn/hooks.d/cfn-auto-reloader.conf
+                  - /lib/systemd/system/cfn-hup.service
+        install_deployer_tools:
+          files:
+            /home/ubuntu/.bash_profile:
+              content: !Sub |
+                # .bash_profile
+
+                # Get the aliases and functions
+                if [ -f ~/.bashrc ]; then
+                        . ~/.bashrc
+                fi
+
+                # User specific environment and startup programs
+
+                PATH=$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH
+
+                export PATH
+              group: ubuntu
+              mode: "000644"
+              owner: ubuntu
+          packages:
+            apt:
+              docker.io: []
+              git: []
+          services:
+            systemd:
+              docker:
+                enabled: true
+                ensureRunning: true
+          commands:
+            01_install_eksctl:
+              command: !Sub |
+                set -ex \
+                && echo "running 01_install_eksctl" \
+                && curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
+                && mv /tmp/eksctl /usr/local/bin \
+                && chmod +x /usr/local/bin/eksctl \
+                && ln -s /usr/local/bin/eksctl /bin/eksctl
+            02_install_kubectl:
+              # TODO: install the version of kubectl that matches the k8s server version specified above
+              command: !Sub |
+                set -ex \
+                && echo "running 02_install_kubectl" \
+                && curl --silent -o /tmp/kubectl https://s3.${AWS::Region}.amazonaws.com/amazon-eks/1.24.7/2022-10-31/bin/linux/amd64/kubectl \
+                && mv /tmp/kubectl /usr/local/bin \
+                && chmod +x /usr/local/bin/kubectl \
+                && ln -s /usr/local/bin/kubectl /bin/kubectl
+            03_docker_for_user:
+              command: !Sub |
+                set -ex \
+                && echo "running 03_docker_for_user" \
+                && usermod -a -G docker ubuntu
+            04_install_tfenv:
+              command: !Sub |
+                set -ex \
+                && echo "running 04_install_tfenv" \
+                && git clone --depth=1 https://github.com/tfutils/tfenv.git /home/ubuntu/.tfenv \
+                && chown -R ubuntu:ubuntu /home/ubuntu/.tfenv \
+                && ln -s /home/ubuntu/.tfenv/bin/* /usr/local/bin \
+                && tfenv install 1.6.6 \
+                && tfenv use 1.6.6
+            05_install_awscli:
+              command: !Sub |
+                set -ex \
+                && echo "running 05_install_awscli" \
+                && pip3 install -U awscli \
+                && ln -s /usr/local/bin/aws /bin/aws
+            06_install_conda:
+              command: !Sub |
+                set -ex \
+                && echo "running 06_install_conda" \
+                && curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -o /tmp/install_miniconda.sh \
+                && chmod 755 /tmp/install_miniconda.sh \
+                && bash /tmp/install_miniconda.sh -b -p /usr/local -u
+            07_install_serverless:
+              command: !Sub |
+                set -ex \
+                && echo "running 07_install_serverless" \
+                && curl -sSL https://nodejs.org/dist/v16.20.0/node-v16.20.0-linux-x64.tar.gz -o /tmp/node-v16.20.0-linux-x64.tar.gz \
+                && tar xvfz /tmp/node-v16.20.0-linux-x64.tar.gz -C /usr/local \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/node /usr/local/bin/ \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/corepack /usr/local/bin/ \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/npx /usr/local/bin/ \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/npm /usr/local/bin/ \
+                && npm install -g serverless \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/serverless /usr/local/bin/ \
+                && ln -sf /usr/local/node-v16.20.0-linux-x64/bin/sls /usr/local/bin/
+            08_create_unity_config_directory:
+              command: !Sub |
+                set -ex \
+                && echo "running 08_create_unity_config_directory" \
+                && mkdir /home/ubuntu/.unity \
+                && chown -R ubuntu:ubuntu /home/ubuntu/.unity
+        install_cloudwatch_agent:
+          commands:
+            01_download_cloudwatch_agent:
+              command: wget https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb
+            02_install_cloudwatch_agent:
+              command: dpkg -i /tmp/amazon-cloudwatch-agent.deb
+            03_configure_cloudwatch_agent:
+              command: !Sub |
+                cat <<EOF > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+                {
+                    "logs": {
+                      "logs_collected": {
+                        "files": {
+                          "collect_list": [
+                            {
+                              "file_path": "/var/log/managementconsole.log",
+                              "log_group_name": "managementconsole-${Project}-${Venue}",
+                              "log_stream_name": "{instance_id}",
+                              "retention_in_days": 30
+                            }
+                          ]
+                        }
+                      }
+                    }
+                }
+                EOF
+            04_start_cloudwatch_agent:
+              command: systemctl start amazon-cloudwatch-agent
+        deploy_management_console:
+          files:
+            /home/ubuntu/.unity/unity.yaml:
+              content: !Sub |
+                GithubToken: ${GithubToken}
+                WorkflowBasePath: /home/ubuntu/management-console/workflowresources/.github/workflows
+                Workdir: /home/ubuntu/management-console/workdir/
+                ConsoleHost: ${PrivateApplicationLoadBalancer.DNSName}:${Port}
+                Project: ${Project}
+                Venue: ${Venue}
+              group: ubuntu
+              mode: "000644"
+              owner: ubuntu
+          commands:
+            01_install_management_console:
+              command: !Sub |
+                set -ex \
+                && echo "running 01_install_management_console" \
+                && { if [ "${MCVersion}" = "latest" ]; then sudo -i -u ubuntu wget -q -O managementconsole.zip "https://github.com/unity-sds/unity-management-console/releases/latest/download/managementconsole.zip"; else sudo -i -u ubuntu wget -q -O managementconsole.zip "https://github.com/unity-sds/unity-management-console/releases/download/${MCVersion}/managementconsole.zip" ; fi } \
+                && sudo -i -u ubuntu unzip managementconsole.zip
+              cwd: /home/ubuntu
+            02_install_service:
+              command: !Sub |
+                set -ex \
+                && echo "running 02_install_service" \
+                && cp scripts/managementconsole.service /etc/systemd/system/managementconsole.service
+              cwd: /home/ubuntu/management-console
+            03_run_management_console:
+              command: !Sub |
+                set -ex \
+                && echo "running 03_run_management_console" \
+                && sudo service managementconsole start
+              cwd: /home/ubuntu/management-console
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Ref AMI
+        InstanceType: !Ref InstanceType
+        EbsOptimized: true
+        SecurityGroupIds:
+          - !Ref ManagementConsoleSecurityGroup
+        IamInstanceProfile:
+          Arn: !GetAtt InstanceProfile.Arn
+        UserData: !Base64
+          Fn::Sub: |
+            #!/bin/bash
+            sudo apt-get -y -o DPkg::Lock::Timeout=-1 update
+            sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
+            mkdir -p /opt/aws/
+            sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+            sudo ln -s /usr/local/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
+            /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource ManagmentConsoleLaunchTemplate --configsets deployer_install --region ${AWS::Region}
+            /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource DeployerAutoScalingGroup --region ${AWS::Region}
+        # Tags for the resources created by the launch template
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Venue
+                Value: !Ref Venue
+              - Key: ServiceArea
+                Value: cs
+              - Key: Component
+                Value: Unity Management Console
+              - Key: Name
+                Value:
+                  Fn::Join:
+                    - "" # Delimiter (empty string means no delimiter)
+                    - - "Unity Management Console ("
+                      - !Ref Project
+                      - "/"
+                      - !Ref Venue
+                      - ")"
+              - Key: Proj
+                Value: !Ref Project
+              - Key: CreatedBy
+                Value: cs
+              - Key: Env
+                Value: !Ref Venue
+              - Key: Stack
+                Value: Unity Management Console
+      # Tags for the launch template itself
+      TagSpecifications:
+        - ResourceType: "launch-template"
+          Tags:
+            - Key: Venue
+              Value: !Ref Venue
+            - Key: ServiceArea
+              Value: cs
+            - Key: Component
+              Value: Unity Management Console
+            - Key: Name
+              Value: Unity Management Console Launch Template
+            - Key: Proj
+              Value: !Ref Project
+            - Key: CreatedBy
+              Value: cs
+            - Key: Env
+              Value: !Ref Venue
+            - Key: Stack
+              Value: Unity Management Console
+
+  DeployerAutoScalingGroup:
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT30M
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier:
+        - !Ref PrivateSubnetID1
+        - !Ref PrivateSubnetID2
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ManagmentConsoleLaunchTemplate
+        Version: !GetAtt ManagmentConsoleLaunchTemplate.LatestVersionNumber
+      MaxSize: "1"
+      MinSize: "1"
+      DesiredCapacity: "1"
+      Tags:
+        - Key: Venue
+          PropagateAtLaunch: false
+          Value: !Ref Venue
+        - Key: ServiceArea
+          PropagateAtLaunch: false
+          Value: cs
+        - Key: Component
+          PropagateAtLaunch: false
+          Value: Unity Management Console
+        - Key: Name
+          PropagateAtLaunch: false
+          Value:
+            Fn::Join:
+              - "" # Delimiter (empty string means no delimiter)
+              - - "Unity Management Console ("
+                - !Ref Project
+                - "/"
+                - !Ref Venue
+                - ")"
+        - Key: Proj
+          PropagateAtLaunch: false
+          Value: !Ref Project
+        - Key: CreatedBy
+          PropagateAtLaunch: false
+          Value: cs
+        - Key: Env
+          PropagateAtLaunch: false
+          Value: !Ref Venue
+        - Key: Stack
+          PropagateAtLaunch: false
+          Value: Unity Management Console
+        - Key: Unique ID
+          PropagateAtLaunch: false
+          Value: !Sub "${RandomStringResource.RandomString}"
+      TargetGroupARNs:
+        - !Ref ManagementConsoleTargetGroup
+
+  ManagementConsoleSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for unity management console instances
+      VpcId: !Ref VPCID
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref Port
+          ToPort: !Ref Port
+          SourceSecurityGroupId: !GetAtt ALBSecurityGroup.GroupId
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity Management Console Instance SG
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for unity management console load balancer
+      VpcId: !Ref VPCID
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref Port
+          ToPort: !Ref Port
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity Management Console Load Balancer SG
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+
+  ManagementConsoleTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 90
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /ping
+      HealthCheckPort: !Ref Port
+      HealthCheckTimeoutSeconds: 60
+      HealthyThresholdCount: 5
+      UnhealthyThresholdCount: 5
+      Port: !Ref Port
+      Protocol: HTTP
+      TargetType: instance
+      VpcId: !Ref VPCID
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity Management Console Target Group
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+
+  PrivateApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      IpAddressType: ipv4
+      LoadBalancerAttributes:
+        - Key: deletion_protection.enabled
+          Value: "false"
+        - Key: idle_timeout.timeout_seconds
+          Value: "300"
+      Name: !Sub "unity-mc-alb-${RandomStringResource.RandomString}"
+      Scheme: internal
+      SecurityGroups:
+        - !GetAtt ALBSecurityGroup.GroupId
+      Subnets:
+        - !Ref PublicSubnetID1
+        - !Ref PublicSubnetID2
+      Type: application
+      Tags:
+        - Key: Venue
+          Value: !Ref Venue
+        - Key: ServiceArea
+          Value: cs
+        - Key: Component
+          Value: Unity Management Console
+        - Key: Name
+          Value: Unity Management Console ALB
+        - Key: Proj
+          Value: !Ref Project
+        - Key: CreatedBy
+          Value: cs
+        - Key: Env
+          Value: !Ref Venue
+        - Key: Stack
+          Value: Unity Management Console
+
+  PrivateLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref ManagementConsoleTargetGroup
+          Type: "forward"
+      LoadBalancerArn: !Ref PrivateApplicationLoadBalancer
+      Port: !Ref Port
+      Protocol: HTTP
+Outputs:
+  ManagementConsoleURL:
+    Description: The URL for the Unity Management Console
+    Value: !Sub "http://${PrivateApplicationLoadBalancer.DNSName}:${Port}/ui/landing"

--- a/nightly_tests/deploy.sh
+++ b/nightly_tests/deploy.sh
@@ -66,7 +66,7 @@ echo "deploying INSTANCE TYPE: ${MC_INSTANCETYPE_VAL} ..."
 
 aws cloudformation create-stack \
   --stack-name ${STACK_NAME} \
-  --template-body file://template.yml \
+  --template-body file://../cloudformation-template/unity-mc.main.template.yaml \
   --capabilities CAPABILITY_IAM \
   --parameters \
     ParameterKey=VPCID,ParameterValue=${VPC_ID_VAL} \

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -141,7 +141,6 @@ echo "---------------------------------------------------------"
 
 export STACK_NAME="unity-management-console-${PROJECT_NAME}-${VENUE_NAME}"
 export GH_BRANCH=main
-export GH_CF_BRANCH=main
 TODAYS_DATE=$(date '+%F_%H-%M')
 LOG_DIR=nightly_logs/log_${TODAYS_DATE}
 
@@ -204,31 +203,21 @@ echo "Repo Hash (Nightly Test):     [$NIGHTLY_HASH]"
 git pull origin ${GH_BRANCH}
 git checkout ${GH_BRANCH}
 
-## update cloudformation scripts
-rm -rf cloudformation
-git clone https://oauth2:$GITHUB_TOKEN_VAL@github.com/unity-sds/cfn-ps-jpl-unity-sds.git cloudformation
-cd cloudformation
-
-## This is for testing a specific branch of the cloudformation repo
-git checkout ${GH_CF_BRANCH}
-git pull origin ${GH_CF_BRANCH}
-
-CLOUDFORMATION_HASH=$(git rev-parse --short HEAD)
-cd ..
+#
 #echo "Using cfn-ps-jpl-unity-sds repo commit [$CLOUDFORMATION_HASH]" >> nightly_output.txt
 #echo"--------------------------------------------------------------------------[PASS]"
 echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]" >> nightly_output.txt
 echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]"
 
-cp ./cloudformation/templates/unity-mc.main.template.yaml template.yml
 
+#
 #
 # Deploy the Management Console using CloudFormation
 #
 bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}"
 
 echo "Sleeping for 360s to give enough time for stack to fully come up..."
-sleep 420  # give enough time for stack to fully come up. TODO: revisit this approach
+sleep 420  # give enough time for stack to fully come up. TODO: revisit this api-0dcab4bf4414c80d2proach
 
 aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
 

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -217,7 +217,7 @@ echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]"
 bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}"
 
 echo "Sleeping for 360s to give enough time for stack to fully come up..."
-sleep 420  # give enough time for stack to fully come up. TODO: revisit this api-0dcab4bf4414c80d2proach
+sleep 420  # give enough time for stack to fully come up. TODO: revisit this appproach
 
 aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
 


### PR DESCRIPTION
## Purpose
- Move cloudformation tempalte from `cfn-ps-jpl-unity-sds` to `unity-infra`

## Proposed Changes
- [ADD] Moved the CloudFormation template from `cfn-ps-jpl-unity-sds` to `unity-infra`.
- [ADD] Created a new directory in `unity-infra` for the CloudFormation template.
- [CHANGE] Updated references to the CloudFormation template in the new location.

## Issues
- unity-sds/unity-cs#443

## Testing
- Tested the changes in the `unity-venue-dev` environment. Everything is working.

I moved the CloudFormation template from `cfn-ps-jpl-unity-sds` into `unity-infra`. I tested the changes in `unity-venue-dev`. Everything is working. I created a new directory and put the CloudFormation template in it. The old repository `cfn-ps-jpl-unity-sds` needs to be deleted.
