### PR TITLE
Remove Deprecated EKS AMI References for Versions 1.26, 1.25, and 1.24

### DIFF
--- a/nightly_tests/set_common_ssm_params.sh
+++ b/nightly_tests/set_common_ssm_params.sh
@@ -201,20 +201,6 @@ populate_if_not_exists_ssm_param "${CERTIFICATE_ARN_SSM}" \
 CERTIFICATE_ARN_VAL=$(get_ssm_val "${CERTIFICATE_ARN_SSM}")
 
 #
-# SSM:  /unity/account/eks/amis/aml2-eks-1-25
-#
-EKS_AMI_25_SSM="/unity/account/eks/amis/aml2-eks-1-25"
-EKS_AMI_25_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-25")
-refresh_ssm_param "${EKS_AMI_25_SSM}" "${EKS_AMI_25_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks125Ssm"
-
-#
-# SSM:  /unity/account/eks/amis/aml2-eks-1-26
-# 
-EKS_AMI_26_SSM="/unity/account/eks/amis/aml2-eks-1-26"
-EKS_AMI_26_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-26")
-refresh_ssm_param "${EKS_AMI_26_SSM}" "${EKS_AMI_26_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks126Ssm"
-
-#
 # SSM:  /unity/account/eks/amis/aml2-eks-1-27
 #
 EKS_AMI_27_SSM="/unity/account/eks/amis/aml2-eks-1-27"

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -32,18 +32,6 @@ data "aws_ssm_parameter" "eks_ami_1_27" {
   name = "/unity/account/eks/amis/aml2-eks-1-27"
 }
 
-data "aws_ssm_parameter" "eks_ami_1_26" {
-  name = "/unity/account/eks/amis/aml2-eks-1-26"
-}
-
-data "aws_ssm_parameter" "eks_ami_1_25" {
-  name = "/unity/account/eks/amis/aml2-eks-1-25"
-}
-#
-#data "aws_ssm_parameter" "eks_ami_1_24" {
-#  name = "/unity/account/eks/amis/aml2-eks-1-24"
-#}
-
 data "aws_iam_policy" "mcp_operator_policy" {
   name = "mcp-tenantOperator-AMI-APIG"
 }

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -6,8 +6,6 @@ locals {
   ami_map = {
     "1.29"    = data.aws_ssm_parameter.eks_ami_1_29.value
     "1.27"    = data.aws_ssm_parameter.eks_ami_1_27.value
-    "1.26"    = data.aws_ssm_parameter.eks_ami_1_26.value
-    "1.25"    = data.aws_ssm_parameter.eks_ami_1_25.value
     "default" = "ami-0f4319b351ce92b6e"
   }
   #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value


### PR DESCRIPTION
## Purpose

The purpose of this PR is to clean up unused Amazon Machine Image (AMI) references and improve the maintainability of the Terraform configuration for the Unity EKS module by removing older AMI versions.

## Proposed Changes

- [REMOVE] AMI data sources for older EKS versions (1.26, 1.25, 1.24) from data.tf and locals.tf.
  - The following AMI parameters were removed:
    - `/unity/account/eks/amis/aml2-eks-1-26`
    - `/unity/account/eks/amis/aml2-eks-1-25`
    - `/unity/account/eks/amis/aml2-eks-1-24` (commented-out section)
  - Updated ami_map to remove references to the removed versions.

## Issues

N/A

## Testing

Verified the changes by running a Terraform depployment to ensure no unintended changes are introduced to the infrastructure.