### PR TITLE
Enhance destroy.sh Script: Directory Creation, Backend Config Management, and MC Failure Handling

### DIFF
--- a/nightly_tests/deploy.sh
+++ b/nightly_tests/deploy.sh
@@ -64,6 +64,9 @@ echo "deploy.sh :: VENUE_NAME: ${VENUE_NAME}"
 source ./set_deployment_ssm_params.sh --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}"
 echo "deploying INSTANCE TYPE: ${MC_INSTANCETYPE_VAL} ..."
 
+echo "Deploying Cloudformation stack..." >> nightly_output.txt
+echo "Deploying Cloudformation stack..."
+
 aws cloudformation create-stack \
   --stack-name ${STACK_NAME} \
   --template-body file://../cloudformation-template/unity-mc.main.template.yaml \

--- a/nightly_tests/destroy.sh
+++ b/nightly_tests/destroy.sh
@@ -116,7 +116,7 @@ EOF
     if ! terraform init -reconfigure; then
         echo "Error: Could not initialize Terraform for ${PROJECT_NAME}/${VENUE_NAME}."
         cd - || exit 1
-        rm -rf "$NAMESPACE_DIR"
+        rm -rf "name-spaces/${PROJECT_NAME}-${VENUE_NAME}"
         exit 1
     fi
 
@@ -125,7 +125,7 @@ EOF
     if ! terraform destroy -auto-approve; then
         echo "Error: Could not delete ${PROJECT_NAME}/${VENUE_NAME} AWS resources."
         cd - || exit 1
-        rm -rf "$NAMESPACE_DIR"
+        rm -rf "name-spaces/${PROJECT_NAME}-${VENUE_NAME}"
         exit 1
     fi
 
@@ -135,7 +135,7 @@ EOF
 
     # Clean up
     cd - || exit 1
-    rm -rf "$NAMESPACE_DIR"
+    rm -rf "name-spaces/${PROJECT_NAME}-${VENUE_NAME}"
     echo "Terraform operations completed. Namespace directory and all Terraform files have been deleted."
     echo "Total duration: $DURATION seconds"
 fi

--- a/nightly_tests/destroy.sh
+++ b/nightly_tests/destroy.sh
@@ -136,6 +136,18 @@ EOF
         exit 1
     fi
 
+    # Delete the DynamoDB table only if the initial stack status was CREATE_COMPLETE
+
+    DYNAMODB_TABLE="${PROJECT_NAME}-${VENUE_NAME}-terraform-state"
+    echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..."
+    echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..." >> nightly_output.txt
+    if ! aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}"; then
+        echo "Error: Could not delete DynamoDB table ${DYNAMODB_TABLE}."
+        exit 1
+    fi
+    echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully"
+    echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully" >> nightly_output.txt
+
     # End the timer
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))
@@ -145,8 +157,8 @@ EOF
     rm -rf "name-spaces/${PROJECT_NAME}-${VENUE_NAME}"
     echo "Terraform operations completed. Namespace directory and all Terraform files have been deleted."
     echo "Terraform operations completed. Namespace directory and all Terraform files have been deleted." >> nightly_output.txt
-    echo "Total duration: $DURATION seconds"
-    echo "Total duration: $DURATION seconds" >> nightly_output.txt
+    echo "MC Teardown: Completed in $DURATION seconds"
+    echo "MC Teardown: Completed in $DURATION seconds" >> nightly_output.txt
 fi
 
 # Delete CloudFormation stack
@@ -198,15 +210,3 @@ fi
 echo "Running destroy_deployment_ssm_params.sh script..."
 ./destroy_deployment_ssm_params.sh --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}"
 
-# Delete the DynamoDB table only if the initial stack status was CREATE_COMPLETE
-if [ "${INITIAL_STACK_STATUS}" == "CREATE_COMPLETE" ]; then
-    DYNAMODB_TABLE="${PROJECT_NAME}-${VENUE_NAME}-terraform-state"
-    echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..."
-    echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..." >> nightly_output.txt
-    if ! aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}"; then
-        echo "Error: Could not delete DynamoDB table ${DYNAMODB_TABLE}."
-        exit 1
-    fi
-    echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully"
-    echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully" >> nightly_output.txt
-fi

--- a/nightly_tests/destroy.sh
+++ b/nightly_tests/destroy.sh
@@ -75,14 +75,28 @@ else
     echo "Terraform installation completed."
 fi
 
-
-
-
 export STACK_NAME="unity-management-console-${PROJECT_NAME}-${VENUE_NAME}"
-# Create Terraform configuration file
-CONFIG_FILE="${PROJECT_NAME}-${VENUE_NAME}.tf"
 
-cat <<EOF > "${CONFIG_FILE}"
+# Check CloudFormation stack status
+echo "Checking CloudFormation stack status..."
+INITIAL_STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "${STACK_NAME}" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+    echo "Error: Unable to retrieve stack status. The stack ${STACK_NAME} may not exist."
+    INITIAL_STACK_STATUS="DOES_NOT_EXIST"
+fi
+
+echo "Current stack status: ${INITIAL_STACK_STATUS}"
+
+if [ "${INITIAL_STACK_STATUS}" == "CREATE_COMPLETE" ]; then
+    # Create namespace directory
+    NAMESPACE_DIR="name-spaces/${PROJECT_NAME}-${VENUE_NAME}"
+    mkdir -p "$NAMESPACE_DIR"
+    cd "$NAMESPACE_DIR" || exit 1
+
+    # Create Terraform configuration file
+    CONFIG_FILE="${PROJECT_NAME}-${VENUE_NAME}.tf"
+    cat <<EOF > "${CONFIG_FILE}"
 terraform {
   backend "s3" {
     bucket         = "unity-${PROJECT_NAME}-${VENUE_NAME}-bucket"
@@ -93,60 +107,51 @@ terraform {
 }
 EOF
 
-echo "Destroying ${PROJECT_NAME}-${VENUE_NAME} Management Console and AWS resources..."
+    echo "Destroying ${PROJECT_NAME}-${VENUE_NAME} Management Console and AWS resources..."
+    # Start the timer
+    START_TIME=$(date +%s)
 
-# Start the timer
-START_TIME=$(date +%s)
+    # Initialize Terraform
+    echo "Initializing Terraform..."
+    if ! terraform init -reconfigure; then
+        echo "Error: Could not initialize Terraform for ${PROJECT_NAME}/${VENUE_NAME}."
+        cd - || exit 1
+        rm -rf "$NAMESPACE_DIR"
+        exit 1
+    fi
 
-# Initialize Terraform
-echo "Initializing Terraform..."
-if ! terraform init -reconfigure; then
-    echo "Error: Could not initialize Terraform for ${PROJECT_NAME}/${VENUE_NAME}."
-    rm -f "${CONFIG_FILE}"
-    rm -rf .terraform/
-    exit 1
+    # Run Terraform Destroy
+    echo "Destroying resources..."
+    if ! terraform destroy -auto-approve; then
+        echo "Error: Could not delete ${PROJECT_NAME}/${VENUE_NAME} AWS resources."
+        cd - || exit 1
+        rm -rf "$NAMESPACE_DIR"
+        exit 1
+    fi
+
+    # End the timer
+    END_TIME=$(date +%s)
+    DURATION=$((END_TIME - START_TIME))
+
+    # Clean up
+    cd - || exit 1
+    rm -rf "$NAMESPACE_DIR"
+    echo "Terraform operations completed. Namespace directory and all Terraform files have been deleted."
+    echo "Total duration: $DURATION seconds"
 fi
 
-# Run Terraform Destroy
-echo "Destroying resources..."
-if ! terraform destroy -auto-approve; then
-    echo "Error: Could not delete ${PROJECT_NAME}/${VENUE_NAME} AWS resources."
-    rm -f "${CONFIG_FILE}"
-    rm -rf .terraform/
-    exit 1
-fi
-
-# End the timer
-END_TIME=$(date +%s)
-DURATION=$((END_TIME - START_TIME))
-
-# Delete the Terraform configuration file
-rm -f "${CONFIG_FILE}"
-rm -f .terraform.lock.hcl
-rm -rf .terraform/
-echo "Terraform configuration file ${CONFIG_FILE} has been deleted."
-
-
-echo "${PROJECT_NAME}-${VENUE_NAME} Management Console and AWS resources destruction complete"
-echo "MC Destruction: Completed in ${DURATION}s - [PASS]"
-
-
+# Delete CloudFormation stack
 echo "Destroying cloudformation stack..."
-
 aws cloudformation delete-stack --stack-name ${STACK_NAME}
 
 STACK_STATUS=""
-
 WAIT_TIME=0
 MAX_WAIT_TIME=2400
 WAIT_BLOCK=20
 
 while [ -z "$STACK_STATUS" ]
 do
-
-    #echo"--------------------------------------------------------------------------[PASS]" 
     echo "Waiting for Cloudformation Stack Termination..............................[$WAIT_TIME]"
-
     aws cloudformation describe-stacks --stack-name ${STACK_NAME} > status.txt
     STACK_STATUS=""
     if [ -s status.txt ]
@@ -155,36 +160,40 @@ do
     else
         STACK_STATUS="TERMINATED"
     fi
-
     sleep $WAIT_BLOCK
     WAIT_TIME=$(($WAIT_BLOCK + $WAIT_TIME))
     if [ "$WAIT_TIME" -gt "$MAX_WAIT_TIME" ] 
     then
-        #echo"--------------------------------------------------------------------------[PASS]" 
         echo ""
         echo "Stack teardown exceeded ${MAX_WAIT_TIME} seconds - [FAIL]" >> nightly_output.txt
         echo "Stack teardown exceeded ${MAX_WAIT_TIME} seconds - [FAIL]"
-
-        exit
+        STACK_STATUS="TIMEOUT"
+        break
     fi
 done
 
-if [ "$STACK_STATUS" == "TERMINATED" ]
-then 
-    #echo"--------------------------------------------------------------------------[PASS]" 
+if [ "$STACK_STATUS" == "TERMINATED" ]; then 
     echo "Stack Teardown: Completed in ${WAIT_TIME}s - [PASS]" >> nightly_output.txt
     echo "Stack Teardown: Completed in ${WAIT_TIME}s - [PASS]"
-
+elif [ "$STACK_STATUS" == "TIMEOUT" ]; then
+    echo "Stack Teardown: Timed out after ${WAIT_TIME}s - [FAIL]" >> nightly_output.txt
+    echo "Stack Teardown: Timed out after ${WAIT_TIME}s - [FAIL]"
+else
+    echo "Stack Teardown: Failed with unknown status - [FAIL]" >> nightly_output.txt
+    echo "Stack Teardown: Failed with unknown status - [FAIL]"
 fi
 
+# Run the destroy_deployment_ssm_params.sh script
+echo "Running destroy_deployment_ssm_params.sh script..."
 ./destroy_deployment_ssm_params.sh --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}"
 
-# Delete the DynamoDB table
-DYNAMODB_TABLE="${PROJECT_NAME}-${VENUE_NAME}-terraform-state"
-echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..."
-if ! aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}"; then
-    echo "Error: Could not delete DynamoDB table ${DYNAMODB_TABLE}."
-    exit 1
+# Delete the DynamoDB table only if the initial stack status was CREATE_COMPLETE
+if [ "${INITIAL_STACK_STATUS}" == "CREATE_COMPLETE" ]; then
+    DYNAMODB_TABLE="${PROJECT_NAME}-${VENUE_NAME}-terraform-state"
+    echo "Deleting DynamoDB table ${DYNAMODB_TABLE}..."
+    if ! aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}"; then
+        echo "Error: Could not delete DynamoDB table ${DYNAMODB_TABLE}."
+        exit 1
+    fi
+    echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully"
 fi
-
-echo "DynamoDB table ${DYNAMODB_TABLE} was deleted successfully"

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -5,6 +5,7 @@ RUN_TESTS=""
 PROJECT_NAME=""
 VENUE_NAME=""
 MC_VERSION="latest"
+DEPLOYMENT_START_TIME=$(date +%s)
 
 # Function to display usage instructions
 usage() {
@@ -288,9 +289,17 @@ end_time=$(date +%s)
 # Calculate the duration
 duration=$((end_time - start_time))
 
-# Output the result
+# MC Creation Time
 echo "Management Console Creation Time: $duration seconds"
 echo "Management Console Creation Time: $duration seconds" >> nightly_output.txt
+
+
+# SSM Creation, CloudFormation, Bootstrap time
+DEPLOYMENT_END_TIME=$(date +%s)
+DEPLOYMENT_DURATION=$((end_time - start_time))
+
+echo "Total Creation Time(SMM params, CloudFormation, MC): $DEPLOYMENT_DURATION seconds"
+echo "Total Creation Time(SMM params, CloudFormation, MC): $DEPLOYMENT_DURATION seconds" >> nightly_output.txt
 
 # Cloud formation smoke_test
 echo "Running Smoke Test"

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -216,7 +216,11 @@ echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]"
 #
 bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}"
 
-echo "Sleeping for 360s to give enough time for stack to fully come up..."
+echo "Sleeping for 360s to give enough time for MC bootstrap process to complete..."
+
+# Start the timer
+start_time=$(date +%s)
+
 sleep 420  # give enough time for stack to fully come up. TODO: revisit this appproach
 
 aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
@@ -286,6 +290,14 @@ while [ $attempt -le $max_attempts ]; do
         ((attempt++))
     fi
 done
+# End the timer
+end_time=$(date +%s)
+
+# Calculate the duration
+duration=$((end_time - start_time))
+
+# Output the result
+echo "The bootstrap process took $duration seconds to complete."
 
 # Cloud formation smoke_test
 echo "Running Smoke Test"

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -218,6 +218,8 @@ start_time=$(date +%s)
 
 aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
 
+sleep 420
+
 # Get MC URL from SSM (Manamgement Console populates this value)
 export SSM_MC_URL="/unity/${PROJECT_NAME}/${VENUE_NAME}/management/httpd/loadbalancer-url"
 export MANAGEMENT_CONSOLE_URL=$(aws ssm get-parameter --name ${SSM_MC_URL}  |grep '"Value":' |sed 's/^.*: "//' | sed 's/".*$//')

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -204,24 +204,16 @@ git pull origin ${GH_BRANCH}
 git checkout ${GH_BRANCH}
 
 #
-#echo "Using cfn-ps-jpl-unity-sds repo commit [$CLOUDFORMATION_HASH]" >> nightly_output.txt
-#echo"--------------------------------------------------------------------------[PASS]"
-echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]" >> nightly_output.txt
-echo "Repo Hash (Cloudformation):   [$CLOUDFORMATION_HASH]"
-
-
-#
-#
 # Deploy the Management Console using CloudFormation
 #
 bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}"
 
-echo "Sleeping for 360s to give enough time for MC bootstrap process to complete..."
+echo "Deploying Management Console..." >> nightly_output.txt
+echo "Deploying Management Console..." >>
 
 # Start the timer
 start_time=$(date +%s)
 
-sleep 420  # give enough time for stack to fully come up. TODO: revisit this appproach
 
 aws cloudformation describe-stack-events --stack-name ${STACK_NAME} >> cloudformation_events.txt
 
@@ -297,7 +289,8 @@ end_time=$(date +%s)
 duration=$((end_time - start_time))
 
 # Output the result
-echo "The bootstrap process took $duration seconds to complete."
+echo "Management Console Creation Time: $duration seconds"
+echo "Management Console Creation Time: $duration seconds" >> nightly_output.txt
 
 # Cloud formation smoke_test
 echo "Running Smoke Test"

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -210,7 +210,7 @@ git checkout ${GH_BRANCH}
 bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}"
 
 echo "Deploying Management Console..." >> nightly_output.txt
-echo "Deploying Management Console..." >>
+echo "Deploying Management Console..."
 
 # Start the timer
 start_time=$(date +%s)

--- a/nightly_tests/run.sh
+++ b/nightly_tests/run.sh
@@ -298,7 +298,7 @@ echo "Management Console Creation Time: $duration seconds" >> nightly_output.txt
 
 # SSM Creation, CloudFormation, Bootstrap time
 DEPLOYMENT_END_TIME=$(date +%s)
-DEPLOYMENT_DURATION=$((end_time - start_time))
+DEPLOYMENT_DURATION=$((DEPLOYMENT_END_TIME - DEPLOYMENT_START_TIME))
 
 echo "Total Creation Time(SMM params, CloudFormation, MC): $DEPLOYMENT_DURATION seconds"
 echo "Total Creation Time(SMM params, CloudFormation, MC): $DEPLOYMENT_DURATION seconds" >> nightly_output.txt


### PR DESCRIPTION
## Purpose
- Update the `destroy.sh` script to improve the handling of Terraform destruction by associating the correct `.tf` files with the destruction process and adding logic to skip Terraform destruction if the MC fails during the CloudFormation stack.

## Proposed Changes
- **[ADD]** Logic to create a new directory within the `destroy.sh` script and place the Terraform backend config file in that directory.
- **[ADD]** Command to change directories (`cd`) into the newly created directory to ensure the correct `.tf` files are associated with the destruction process.
- **[ADD]** Logic to skip the Terraform destruction step if the MC fails during the CloudFormation stack process.
- **[ADD]** Timing of logs to bootstrap process

## Testing
- Verified that the script correctly creates a new directory, adds the Terraform backend config file, changes directories, and appropriately skips the destruction process when the MC fails.
- Test results available in the attached screenshots 
![Screenshot 2024-08-22 at 4 29 09 PM](https://github.com/user-attachments/assets/e67a4ed5-ec5f-4a75-9bbb-0aed26114cd2)

![Screenshot 2024-08-22 at 4 29 31 PM](https://github.com/user-attachments/assets/f85c1719-139a-411f-a0fe-26f49a062844)
