### PR TITLE
Removing wildcard ALB ingress rule

### DIFF
--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -629,11 +629,6 @@ Resources:
     Properties:
       GroupDescription: Security group for unity management console load balancer
       VpcId: !Ref VPCID
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: !Ref Port
-          ToPort: !Ref Port
-          CidrIp: 0.0.0.0/0
       Tags:
         - Key: Venue
           Value: !Ref Venue


### PR DESCRIPTION
## Purpose
- Removing the wildcard (`0.0.0.0/0`) ingress rule from the managementconsole's ALB security group defaults, locking down external access
    - access to be granted specifically to the ECS venue-services proxy by unity-sds/unity-proxy#6
## Proposed Changes
- REMOVE `SecurityGroupIngress` entry from ALBSecurityGroup in the cloudformation template
## Issues
- second part of unity-sds/unity-cs#431
## Testing
- Manually deployed a management console instance, and ensured through testing and checking in the AWS console that the securitygroup had no ingress rules.