### PR TITLE
Correct KMS Key Reference for EBS Volume Encryption

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -53,3 +53,7 @@ data "aws_iam_policy" "aws-managed-load-balancer-policy" {
 }
 
 data "aws_ebs_default_kms_key" "current" {}
+
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -36,7 +36,7 @@ locals {
             volume_size           = mapping.ebs.volume_size
             volume_type           = mapping.ebs.volume_type
             encrypted             = mapping.ebs.encrypted
-            kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+            kms_key_id            = data.aws_kms_key.current.arn
             delete_on_termination = mapping.ebs.delete_on_termination
           }
         }


### PR DESCRIPTION
## Purpose

- Address an issue with AWS KMS keys used in the EKS module where the incorrect KMS key ID was being referenced.
- Ensure proper referencing of the AWS KMS key for encryption of EBS volumes.

## Proposed Changes
- [ADD] Data block for retrieving the correct AWS KMS key.
- [CHANGE] Updated KMS key ID reference in locals.tf to use the correct AWS KMS key ARN instead of the default KMS key ID.
- [FIX] Ensure the EBS volume encryption uses the correct KMS key for AWS-managed keys.
## Issues
- NA
## Testing
- Successfully manually deployed an EKS cluster with these changes in `unity-sbg-dev`.