### PR TITLE
Use an NLB instead of the existing ALB as Management Console Load balancer

### DIFF
--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -57,7 +57,7 @@ Metadata:
       Project:
         default: Name of the project that owns and operates the account
       Port:
-        default: Port used for the Managmente Console ALB
+        default: Port used for the Managmente Console NLB
       AMI:
         default: AMI id used for deploying the Management Console
 
@@ -449,7 +449,7 @@ Resources:
                 GithubToken: ${GithubToken}
                 WorkflowBasePath: /home/ubuntu/management-console/workflowresources/.github/workflows
                 Workdir: /home/ubuntu/management-console/workdir/
-                ConsoleHost: ${PrivateApplicationLoadBalancer.DNSName}:${Port}
+                ConsoleHost: ${PrivateNetworkLoadBalancer.DNSName}:${Port}
                 Project: ${Project}
                 Venue: ${Venue}
               group: ubuntu
@@ -605,7 +605,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref Port
           ToPort: !Ref Port
-          SourceSecurityGroupId: !GetAtt ALBSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt NLBSecurityGroup.GroupId
       Tags:
         - Key: Venue
           Value: !Ref Venue
@@ -624,7 +624,7 @@ Resources:
         - Key: Stack
           Value: Unity Management Console
 
-  ALBSecurityGroup:
+  NLBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Security group for unity management console load balancer
@@ -679,7 +679,7 @@ Resources:
         - Key: Stack
           Value: Unity Management Console
 
-  PrivateApplicationLoadBalancer:
+  PrivateNetworkLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       IpAddressType: ipv4
@@ -688,14 +688,14 @@ Resources:
           Value: "false"
         - Key: idle_timeout.timeout_seconds
           Value: "300"
-      Name: !Sub "unity-mc-alb-${RandomStringResource.RandomString}"
+      Name: !Sub "unity-mc-nlb-${RandomStringResource.RandomString}"
       Scheme: internal
       SecurityGroups:
-        - !GetAtt ALBSecurityGroup.GroupId
+        - !GetAtt NLBSecurityGroup.GroupId
       Subnets:
         - !Ref PublicSubnetID1
         - !Ref PublicSubnetID2
-      Type: application
+      Type: network
       Tags:
         - Key: Venue
           Value: !Ref Venue
@@ -704,7 +704,7 @@ Resources:
         - Key: Component
           Value: Unity Management Console
         - Key: Name
-          Value: Unity Management Console ALB
+          Value: Unity Management Console NLB
         - Key: Proj
           Value: !Ref Project
         - Key: CreatedBy
@@ -720,10 +720,10 @@ Resources:
       DefaultActions:
         - TargetGroupArn: !Ref ManagementConsoleTargetGroup
           Type: "forward"
-      LoadBalancerArn: !Ref PrivateApplicationLoadBalancer
+      LoadBalancerArn: !Ref PrivateNetworkLoadBalancer
       Port: !Ref Port
       Protocol: HTTP
 Outputs:
   ManagementConsoleURL:
     Description: The URL for the Unity Management Console
-    Value: !Sub "http://${PrivateApplicationLoadBalancer.DNSName}:${Port}/ui/landing"
+    Value: !Sub "http://${PrivateNetworkLoadBalancer.DNSName}:${Port}/ui/landing"

--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -686,8 +686,6 @@ Resources:
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
           Value: "false"
-        - Key: idle_timeout.timeout_seconds
-          Value: "300"
       Name: !Sub "unity-mc-nlb-${RandomStringResource.RandomString}"
       Scheme: internal
       SecurityGroups:

--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -651,14 +651,14 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 90
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: TCP
       HealthCheckPath: /ping
       HealthCheckPort: !Ref Port
       HealthCheckTimeoutSeconds: 60
       HealthyThresholdCount: 5
       UnhealthyThresholdCount: 5
       Port: !Ref Port
-      Protocol: HTTP
+      Protocol: TCP
       TargetType: instance
       VpcId: !Ref VPCID
       Tags:
@@ -720,7 +720,7 @@ Resources:
           Type: "forward"
       LoadBalancerArn: !Ref PrivateNetworkLoadBalancer
       Port: !Ref Port
-      Protocol: HTTP
+      Protocol: TCP
 Outputs:
   ManagementConsoleURL:
     Description: The URL for the Unity Management Console

--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -652,7 +652,6 @@ Resources:
     Properties:
       HealthCheckIntervalSeconds: 90
       HealthCheckProtocol: TCP
-      HealthCheckPath: /ping
       HealthCheckPort: !Ref Port
       HealthCheckTimeoutSeconds: 60
       HealthyThresholdCount: 5

--- a/nightly_tests/deploy.sh
+++ b/nightly_tests/deploy.sh
@@ -12,7 +12,7 @@ usage() {
 }
 
 #
-# It's mandatory to speciy a valid command arguments
+# It's mandatory to specify a valid command arguments
 #
 # if [[ $# -ne 6 ]]; then
 #  usage


### PR DESCRIPTION
## Purpose

This pull request will introduce an NLB instead of the existing ALB, as Management Console Load balancer. NLB is required to connect a RESTful API Gateway to the Management Console  Health Checks through a VPC Link.

## Proposed Changes
- [CHANGE] Use NLB instead of the existing ALB, as Management Console Load balancer

