### PR TITLE
chore: Update EKS AMIs

### DIFF
--- a/nightly_tests/set_common_ssm_params.sh
+++ b/nightly_tests/set_common_ssm_params.sh
@@ -201,11 +201,11 @@ populate_if_not_exists_ssm_param "${CERTIFICATE_ARN_SSM}" \
 CERTIFICATE_ARN_VAL=$(get_ssm_val "${CERTIFICATE_ARN_SSM}")
 
 #
-# SSM:  /unity/account/eks/amis/aml2-eks-1-27
+# SSM:  /unity/account/eks/amis/aml2-eks-1-28
 #
-EKS_AMI_27_SSM="/unity/account/eks/amis/aml2-eks-1-27"
-EKS_AMI_27_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-27")
-refresh_ssm_param "${EKS_AMI_27_SSM}" "${EKS_AMI_27_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks127Ssm"
+EKS_AMI_28_SSM="/unity/account/eks/amis/aml2-eks-1-28"
+EKS_AMI_28_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-28")
+refresh_ssm_param "${EKS_AMI_28_SSM}" "${EKS_AMI_28_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks128Ssm"
 
 #
 # SSM:  /unity/account/eks/amis/aml2-eks-1-29
@@ -213,6 +213,13 @@ refresh_ssm_param "${EKS_AMI_27_SSM}" "${EKS_AMI_27_VAL}" "processing" "na" "vpc
 EKS_AMI_29_SSM="/unity/account/eks/amis/aml2-eks-1-29"
 EKS_AMI_29_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-29")
 refresh_ssm_param "${EKS_AMI_29_SSM}" "${EKS_AMI_29_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks129Ssm"
+
+#
+# SSM:  /unity/account/eks/amis/aml2-eks-1-30
+#
+EKS_AMI_30_SSM="/unity/account/eks/amis/aml2-eks-1-30"
+EKS_AMI_30_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-30")
+refresh_ssm_param "${EKS_AMI_30_SSM}" "${EKS_AMI_30_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks130Ssm"
 
 #
 # SSM:  /unity/shared-services/account

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -24,12 +24,16 @@ data "aws_ssm_parameter" "subnet_list" {
 #  name = "/unity/account/eks/eks_iam_role"
 #}
 
+data "aws_ssm_parameter" "eks_ami_1_30" {
+  name = "/unity/account/eks/amis/aml2-eks-1-30"
+}
+
 data "aws_ssm_parameter" "eks_ami_1_29" {
   name = "/unity/account/eks/amis/aml2-eks-1-29"
 }
 
-data "aws_ssm_parameter" "eks_ami_1_27" {
-  name = "/unity/account/eks/amis/aml2-eks-1-27"
+data "aws_ssm_parameter" "eks_ami_1_28" {
+  name = "/unity/account/eks/amis/aml2-eks-1-28"
 }
 
 data "aws_iam_policy" "mcp_operator_policy" {

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -4,8 +4,9 @@ locals {
   subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
   #ami = "ami-0e3e9697a56f6ba66"
   ami_map = {
+    "1.30"    = data.aws_ssm_parameter.eks_ami_1_30.value
     "1.29"    = data.aws_ssm_parameter.eks_ami_1_29.value
-    "1.27"    = data.aws_ssm_parameter.eks_ami_1_27.value
+    "1.28"    = data.aws_ssm_parameter.eks_ami_1_28.value
     "default" = "ami-0f4319b351ce92b6e"
   }
   #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value


### PR DESCRIPTION
## Purpose

The purpose of this PR is to update the EKS AMI references in the Terraform and SSM parameter files to ensure the latest versions (1.28 and 1.30) are being used for EKS cluster deployments.

## Proposed Changes

[ADD] Added support for EKS AMI version 1.28 and 1.30 in both the nightly_tests/set_common_ssm_params.sh script and the Terraform configuration files.
[CHANGE] Updated the SSM parameter file references to include the new AMI versions, ensuring the correct AMIs are used in the eks_ami mappings.
[FIX] Corrected parameter mappings for EKS AMIs in the SSM and Terraform configurations.

## Issues

- N/A

## Testing

- N/A