### PR TITLE
Upgrade Management Console cloudformation to use version to 1.8.2

### DIFF
--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -385,8 +385,8 @@ Resources:
                 && git clone --depth=1 https://github.com/tfutils/tfenv.git /home/ubuntu/.tfenv \
                 && chown -R ubuntu:ubuntu /home/ubuntu/.tfenv \
                 && ln -s /home/ubuntu/.tfenv/bin/* /usr/local/bin \
-                && tfenv install 1.6.6 \
-                && tfenv use 1.6.6
+                && tfenv install 1.8.2 \
+                && tfenv use 1.8.2
             05_install_awscli:
               command: !Sub |
                 set -ex \


### PR DESCRIPTION
## Purpose
- Bump the chosen version of terraform (installed by the cloudformation template) from 1.6.6 to 1.8.2

## Proposed Changes
- CHANGE tfenv install and use commands to version 1.8.2

## Issues
- Requirement for SPS marketplace item updates unity-sds/unity-sps#59

## Testing
- Tested on personal deployment of management console without issue (basic deployment only, was not tested with various applications besides sps/airflow (jupyter, etc)