### PR TITLE
Handle IAM Role Creation and Policy Reapplication

### DIFF
--- a/aws_role_create/U-CS_Service_Policy.json
+++ b/aws_role_create/U-CS_Service_Policy.json
@@ -17,7 +17,10 @@
                 "events:DescribeRule",
                 "events:ListTagsForResource",
                 "events:RemoveTargets",
-                "events:DeleteRule"
+                "events:DeleteRule",
+                "iam:CreatePolicyVersion",
+               "iam:DeletePolicyVersion",
+               "iam:ListPolicyVersions"
             ],
             "Resource": [
                 "arn:aws:ec2:*:*:subnet/*",
@@ -32,7 +35,8 @@
                 "arn:aws:iam::*:role/unity-cs-nightly-*",
                 "arn:aws:iam::*:role/u-cs-ecs-use-eks",
                 "arn:aws:logs:*:*:log-group:*",
-                "arn:aws:events:*:*:rule/*"
+                "arn:aws:events:*:*:rule/*",
+                "arn:aws:iam::*:policy/*"
             ]
         },
         {

--- a/aws_role_create/create_roles_and_policies.sh
+++ b/aws_role_create/create_roles_and_policies.sh
@@ -2,72 +2,91 @@
 
 # ================================================
 # This bash script automates the process of
-# creating an IAM role (Unity-CS_Service_Role)
+# creating or updating an IAM role (Unity-CS_Service_Role)
 # for MDPS, attaching multiple policies to it,
 # and creating an instance profile for that role.
 # ================================================
 
 ROLE_NAME="Unity-CS_Service_Role"
 POLICY_LIST=(AmazonEC2ContainerRegistryPowerUser AmazonS3ReadOnlyAccess AmazonSSMManagedInstanceCore CloudWatchAgentServerPolicy DatalakeKinesisPolicy McpToolsAccessPolicy U-CS_Service_Policy U-CS_Service_Policy_Ondemand)
+CUSTOM_POLICY_LIST=(U-CS_Service_Policy U-CS_Service_Policy_Ondemand)
 
 # Required role for spot ec2/fleet creation
-aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
+aws iam create-service-linked-role --aws-service-name spot.amazonaws.com 2>/dev/null || true
 
 ## Get the account number
-aws sts get-caller-identity > identity.txt
-ACCOUNT_NUMBER=$(cat identity.txt|jq -r '.Account')
+ACCOUNT_NUMBER=$(aws sts get-caller-identity --query Account --output text)
 echo "Account Number: $ACCOUNT_NUMBER"
 
-## Create the role to act as a service role
-echo "Creating role ${ROLE_NAME} ..."
-aws iam create-role \
-    --role-name ${ROLE_NAME} \
-    --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/mcp-tenantOperator-AMI-APIG \
-    --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json  > role.txt
-cat role.txt
-ROLE_ARN=$(cat role.txt|jq -r '.Role.Arn')
-rm role.txt
-echo "Role ARN: $ROLE_ARN"
+# Function to create or update a policy
+create_or_update_policy() {
+    local policy_name=$1
+    local policy_file=$2
+    
+    if aws iam get-policy --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} 2>/dev/null; then
+        echo "Updating policy ${policy_name}..."
+        policy_version=$(aws iam create-policy-version --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --policy-document file://${policy_file} --set-as-default --query 'PolicyVersion.VersionId' --output text)
+        aws iam delete-policy-versions --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --versions-to-delete $(aws iam list-policy-versions --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text)
+    else
+        echo "Creating policy ${policy_name}..."
+        aws iam create-policy \
+            --policy-name ${policy_name} \
+            --policy-document file://${policy_file} \
+            --description "Policy for automated U-CS Operations" \
+            --tags Key=ServiceArea,Value=U-CS
+    fi
+}
 
-## Add the inline policy
+# Check if role exists, create if it doesn't
+if ! aws iam get-role --role-name ${ROLE_NAME} 2>/dev/null; then
+    echo "Creating role ${ROLE_NAME}..."
+    aws iam create-role \
+        --role-name ${ROLE_NAME} \
+        --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/mcp-tenantOperator-AMI-APIG \
+        --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json
+else
+    echo "Role ${ROLE_NAME} already exists."
+fi
+
+# Add or update the inline policy
+echo "Adding/Updating inline policy U-CS_Minimum_ECS-Policy..."
 aws iam put-role-policy \
     --role-name ${ROLE_NAME} \
     --policy-name U-CS_Minimum_ECS-Policy \
     --policy-document file://Minimum_ECS_Policy.json
 
-## U-CS Managed (These need to be created beforehand)
-# U-CS_Service_Policy
-aws iam create-policy \
-    --policy-name U-CS_Service_Policy \
-    --policy-document file://U-CS_Service_Policy.json \
-    --description "Policy containing permissions for automated U-CS Operations" \
-    --tags Key=ServiceArea,Value=U-CS
-
-# U-CS_Service_Policy_Ondemand
-aws iam create-policy \
-    --policy-name U-CS_Service_Policy_Ondemand \
-    --policy-document file://U-CS_Service_Policy_Ondemand.json \
-    --description "Policy containing additional permissions for automated U-CS Operations" \
-    --tags Key=ServiceArea,Value=U-CS
-
-## Get the arns for the policies that we need attached
-aws iam list-policies > policies.list
-
-## Attach the proper policies to the role
-for POLICY_NAME in "${POLICY_LIST[@]}"
-do
-    POLICY_ARN=$(cat policies.list |jq '.Policies[]' |jq 'select(.PolicyName == "'${POLICY_NAME}'")' |jq -r '.Arn')
-    echo "POLICY_ARN: $POLICY_ARN"
-    aws iam attach-role-policy \
-    --role-name ${ROLE_NAME} \
-    --policy-arn ${POLICY_ARN}
+# Create or update custom managed policies
+for POLICY_NAME in "${CUSTOM_POLICY_LIST[@]}"; do
+    create_or_update_policy ${POLICY_NAME} "${POLICY_NAME}.json"
 done
 
-rm policies.list
+# Attach policies to the role
+for POLICY_NAME in "${POLICY_LIST[@]}"; do
+    if [[ " ${CUSTOM_POLICY_LIST[@]} " =~ " ${POLICY_NAME} " ]]; then
+        POLICY_ARN="arn:aws:iam::${ACCOUNT_NUMBER}:policy/${POLICY_NAME}"
+    else
+        POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='${POLICY_NAME}'].Arn" --output text)
+    fi
+    
+    echo "Attaching policy ${POLICY_NAME} to role ${ROLE_NAME}..."
+    aws iam attach-role-policy \
+        --role-name ${ROLE_NAME} \
+        --policy-arn ${POLICY_ARN}
+done
 
-## Attach 
-aws iam delete-instance-profile --instance-profile-name ${ROLE_NAME}-instance-profile
-aws iam create-instance-profile --instance-profile-name ${ROLE_NAME}-instance-profile
-aws iam add-role-to-instance-profile \
-    --instance-profile-name ${ROLE_NAME}-instance-profile \
-    --role-name ${ROLE_NAME}
+# Create or update instance profile
+if ! aws iam get-instance-profile --instance-profile-name ${ROLE_NAME}-instance-profile 2>/dev/null; then
+    echo "Creating instance profile ${ROLE_NAME}-instance-profile..."
+    aws iam create-instance-profile --instance-profile-name ${ROLE_NAME}-instance-profile
+    aws iam add-role-to-instance-profile \
+        --instance-profile-name ${ROLE_NAME}-instance-profile \
+        --role-name ${ROLE_NAME}
+else
+    echo "Instance profile ${ROLE_NAME}-instance-profile already exists."
+    # Ensure the role is attached to the instance profile
+    aws iam add-role-to-instance-profile \
+        --instance-profile-name ${ROLE_NAME}-instance-profile \
+        --role-name ${ROLE_NAME} 2>/dev/null || true
+fi
+
+echo "Role and policies setup completed."

--- a/aws_role_create/create_roles_and_policies.sh
+++ b/aws_role_create/create_roles_and_policies.sh
@@ -26,7 +26,10 @@ create_or_update_policy() {
     if aws iam get-policy --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} 2>/dev/null; then
         echo "Updating policy ${policy_name}..."
         policy_version=$(aws iam create-policy-version --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --policy-document file://${policy_file} --set-as-default --query 'PolicyVersion.VersionId' --output text)
-        aws iam delete-policy-versions --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --versions-to-delete $(aws iam list-policy-versions --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text)
+        OLD_VERSIONS=$(aws iam list-policy-versions --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text)
+        for VERSION in $OLD_VERSIONS; do
+            aws iam delete-policy-version --policy-arn arn:aws:iam::${ACCOUNT_NUMBER}:policy/${policy_name} --version-id $VERSION
+        done
     else
         echo "Creating policy ${policy_name}..."
         aws iam create-policy \


### PR DESCRIPTION
## Purpose
- Update the script to handle reapplying policies to an existing IAM role, or create the role and policies if they don't exist.

## Proposed Changes
- **[ADD]** Logic to apply policies to existing IAM roles.
- **[CHANGE]** Updated script to check for role existence before applying policies.
- **[FIX]** Handling of roles that may already have policies attached.

## Issues
-  unity-sds/unity-cs#498

## Testing
- Tested on unity-cm

