### PR TITLE
changing deployment_name references to project/venue

### DIFF
--- a/terraform-project-api-gateway_module/variables.tf
+++ b/terraform-project-api-gateway_module/variables.tf
@@ -4,15 +4,15 @@ variable "ssm_region" {
   default     = "/unity/shared-services/aws/account/region"
 }
 
-variable "ssm_account_id"{
+variable "ssm_account_id" {
   description = "Name of the SSM paramter for shared service account ID"
-  type = string
-  default = "/unity/shared-services/aws/account"
+  type        = string
+  default     = "/unity/shared-services/aws/account"
 }
 
 variable "tags" {
   description = "AWS Tags"
-  type = map(string)
+  type        = map(string)
 }
 
 variable "deployment_name" {
@@ -21,20 +21,20 @@ variable "deployment_name" {
 }
 variable "project" {
   description = "The unity project its installed into"
-  type = string
-  default = "UnknownProject"
+  type        = string
+  default     = "UnknownProject"
 }
 
 variable "venue" {
   description = "The unity venue its installed into"
-  type = string
-  default = "UnknownVenue"
+  type        = string
+  default     = "UnknownVenue"
 }
 
 variable "installprefix" {
   description = "The management console install prefix"
-  type = string
-  default = "UnknownPrefix"
+  type        = string
+  default     = "UnknownPrefix"
 }
 
 variable "rest_api_stage" {


### PR DESCRIPTION
## Purpose
- The management console sets `deployment_name` as 'default', which is causing name collisions/errors deploying parts of the apigateway. This PR changes those `deployment_name` references to the (more) unique project/venue pairs we use elsewhere.
## Proposed Changes
- CHANGE `${deployment_name}` references to `${project}-${venue}`

## Issues
- no relevant issues, ran into this while deploying a personal management console