### PR TITLE
Adjustments to eks module catering to management console installs

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -61,3 +61,22 @@ data "aws_ebs_default_kms_key" "current" {}
 data "aws_kms_key" "current" {
   key_id = data.aws_ebs_default_kms_key.current.key_arn
 }
+
+# Find the MC's ALB's security group so we can allow connections to the cluster
+data "aws_security_groups" "mc_sg" {
+  filter {
+    name   = "tag:Name"
+    values = ["Unity Management Console Instance SG"]
+  }
+  filter {
+    name   = "tag:Venue"
+    values = [var.venue]
+  }
+  filter {
+    name   = "tag:Proj"
+    values = [var.project]
+  }
+  tags = {
+    ServiceArea = "cs"
+  }
+}

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -22,7 +22,7 @@ variable "nodegroups" {
     capacity_type              = optional(string)
     enable_bootstrap_user_data = optional(bool)
     metadata_options           = optional(map(any))
-    block_device_mappings      = optional(map(object({
+    block_device_mappings = optional(map(object({
       device_name = string
       ebs = object({
         volume_size           = number


### PR DESCRIPTION
## Purpose

- Adding in a specially targeted security group ingress to the created eks clusters to allow the creating management console to connect to them

## Proposed Changes

- ADD the new security group, security group lookup, and conditional ingress rule
- CHANGE the EKS module call to auto-include the new security group

## Issues

- dependency of the work in unity-sds/unity-sps#245
   - related to issue unity-sds/unity-sps#59

## Testing

- Tested during SPS deployment testing, currently deployed as part of https://www.dev.mdps.mcp.nasa.gov:4443/btl-df1/dev/sps/