### PR TITLE
Updated Unity-CS lambda authorizer version to 1.0.4

### DIFF
--- a/terraform-project-api-gateway_module/variables.tf
+++ b/terraform-project-api-gateway_module/variables.tf
@@ -71,7 +71,7 @@ variable "unity_cs_lambda_authorizer_function_name" {
 variable "unity_cs_lambda_authorizer_zip_path" {
   type        = string
   description = "The URL of the CS Lambda Authorizer deployment ZIP file"
-  default     = "https://github.com/unity-sds/unity-cs-auth-lambda/releases/download/1.0.3/unity-cs-lambda-auth-1.0.3.zip"
+  default     = "https://github.com/unity-sds/unity-cs-auth-lambda/releases/download/1.0.4/unity-cs-lambda-auth-1.0.4.zip"
 }
 
 variable "ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn" {


### PR DESCRIPTION
## Purpose
- Updated Unity-CS lambda authorizer version to 1.0.4 to fix Bug: Unity CS Lambda Authorizer of API Gateway fails to handle Cognito access tokens without cognito-groups section
## Proposed Changes
- [FIX] Bug: Unity CS Lambda Authorizer of API Gateway fails to handle Cognito access tokens without cognito-groups section
## Issues
https://github.com/unity-sds/unity-cs/issues/524
