### PR TITLE
Removing references to removed IAM policies in terraform-unity-eks_module

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -36,14 +36,6 @@ data "aws_iam_policy" "mcp_operator_policy" {
   name = "mcp-tenantOperator-AMI-APIG"
 }
 
-data "aws_iam_policy" "datalakekinesis" {
-  name = "DatalakeKinesisPolicy"
-}
-
-data "aws_iam_policy" "mcptools" {
-  name = "McpToolsAccessPolicy"
-}
-
 data "aws_iam_policy" "ebs_csi_policy" {
   name = "U-CS_Service_Policy"
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -62,16 +62,6 @@ resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
-resource "aws_iam_role_policy_attachment" "kinesis" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = data.aws_iam_policy.datalakekinesis.arn
-}
-
-resource "aws_iam_role_policy_attachment" "mcptools" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = data.aws_iam_policy.mcptools.arn
-}
-
 
 resource "aws_iam_role_policy_attachment" "node-policy" {
   role       = aws_iam_role.cluster_iam_role.name


### PR DESCRIPTION
## Purpose
- Removing references to removed IAM policies in terraform-unity-eks_module

## Proposed Changes
- REMOVE data references and iam policy attach directives
## Issues
- N/A

## Testing
- Tested through manual removal on personal deploy of SPS EKS cluster
