### PR TITLE
added support for EKS 1.31

### DIFF
--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -8,21 +8,9 @@ data "aws_ssm_parameter" "subnet_list" {
   name = "/unity/account/network/subnet_list"
 }
 
-#data "aws_ssm_parameter" "cluster_sg" {
-#  name = "/unity/account/eks/cluster_sg"
-#}
-#
-#data "aws_ssm_parameter" "node_sg" {
-#  name = "/unity/account/eks/node_sg"
-#}
-
-#data "aws_ssm_parameter" "eks_iam_node_role" {
-#  name = "/unity/account/eks/eks_iam_node_role"
-#}
-#
-#data "aws_ssm_parameter" "eks_iam_role" {
-#  name = "/unity/account/eks/eks_iam_role"
-#}
+data "aws_ssm_parameter" "eks_ami_1_31" {
+  name = "/mcp/amis/aml2-eks-1-31"
+}
 
 data "aws_ssm_parameter" "eks_ami_1_30" {
   name = "/unity/account/eks/amis/aml2-eks-1-30"

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -4,11 +4,11 @@ locals {
   subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
   #ami = "ami-0e3e9697a56f6ba66"
   ami_map = {
+    "1.31"    = data.aws_ssm_parameter.eks_ami_1_31.value
     "1.30"    = data.aws_ssm_parameter.eks_ami_1_30.value
     "1.29"    = data.aws_ssm_parameter.eks_ami_1_29.value
     "default" = "ami-0f4319b351ce92b6e"
   }
-  #iam_arn = data.aws_ssm_parameter.eks_iam_node_role.value
   mergednodegroups = { for name, ng in var.nodegroups :
     name => {
       use_name_prefix            = false

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -337,6 +337,11 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       most_recent = true
+      configuration_values = jsonencode({
+        defaultStorageClass = {
+          enabled = true
+        }
+      })
     }
     aws-efs-csi-driver = {
       most_recent = true
@@ -736,27 +741,3 @@ resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
     ]
   })
 }
-
-
-#module "irsa-ebs-csi" {
-#  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-#  version = "4.7.0"
-#
-#  create_role                   = false
-#  #role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
-#  role_name = "U-CS_Service_Role"
-#  provider_url                  = module.eks.oidc_provider
-#  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
-#  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
-#}
-
-#resource "aws_eks_addon" "ebs-csi" {
-#  cluster_name             = module.eks.cluster_name
-#  addon_name               = "aws-ebs-csi-driver"
-#  addon_version            = "v1.20.0-eksbuild.1"
-#  service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
-#  tags = {
-#    "eks_addon" = "ebs-csi"
-#    "terraform" = "true"
-#  }
-#}

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -55,7 +55,7 @@ variable "aws_auth_roles" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.29"
+  default = "1.31"
 }
 
 variable "project" {


### PR DESCRIPTION
I know the branch name says "1.32", i created the branch before seeing MCP didn't have a 1.32 AMI to use...

## Purpose
- Add support for deployment of EKS 1.31 
## Proposed Changes
- [ADDED}  1.31 as an option for EKS deployments
- [CHANGE] declared default=true on EBC CSI to support 1.31
- [FIX] REMOVED commented out blocks of code. 
## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- Ran deployment of EKS module multiple times with SPS airflow deployment

