### PR TITLE
SMCE transition and AL2023 upgrade 

### DIFF
--- a/aws_role_create/create_roles_and_policies.sh
+++ b/aws_role_create/create_roles_and_policies.sh
@@ -45,7 +45,7 @@ if ! aws iam get-role --role-name ${ROLE_NAME} 2>/dev/null; then
     echo "Creating role ${ROLE_NAME}..."
     aws iam create-role \
         --role-name ${ROLE_NAME} \
-        --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/mcp-tenantOperator-AMI-APIG \
+        --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/smce-tenantOperator-AMI-APIG \
         --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json
 else
     echo "Role ${ROLE_NAME} already exists."

--- a/aws_role_create/create_roles_and_policies.sh
+++ b/aws_role_create/create_roles_and_policies.sh
@@ -45,7 +45,7 @@ if ! aws iam get-role --role-name ${ROLE_NAME} 2>/dev/null; then
     echo "Creating role ${ROLE_NAME}..."
     aws iam create-role \
         --role-name ${ROLE_NAME} \
-        --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/smce-tenantOperator-AMI-APIG \
+        --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/zsmce-tenantOperator-AMI-APIG \
         --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json
 else
     echo "Role ${ROLE_NAME} already exists."

--- a/aws_role_create/run.sh
+++ b/aws_role_create/run.sh
@@ -85,7 +85,7 @@ echo "Account Number: $ACCOUNT_NUMBER"
 
 ## Create the role to act as a service role
 #aws iam create-role --role-name U-CS-Service-Role-Test --permission-boundary arn:aws:iam::865428270474:policy/mcp-tenantOperator-AMI-APIG --output role.out
-aws iam create-role --role-name ${ROLE_NAME} --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/mcp-tenantOperator-AMI-APIG --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json --profile ${ACCOUNT_NAME} > role.txt
+aws iam create-role --role-name ${ROLE_NAME} --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/smce-tenantOperator-AMI-APIG --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json --profile ${ACCOUNT_NAME} > role.txt
 cat role.txt
 ROLE_ARN=$(cat role.txt|jq -r '.Role.Arn')
 echo "Role ARN: $ROLE_ARN"

--- a/aws_role_create/run.sh
+++ b/aws_role_create/run.sh
@@ -85,7 +85,7 @@ echo "Account Number: $ACCOUNT_NUMBER"
 
 ## Create the role to act as a service role
 #aws iam create-role --role-name U-CS-Service-Role-Test --permission-boundary arn:aws:iam::865428270474:policy/mcp-tenantOperator-AMI-APIG --output role.out
-aws iam create-role --role-name ${ROLE_NAME} --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/smce-tenantOperator-AMI-APIG --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json --profile ${ACCOUNT_NAME} > role.txt
+aws iam create-role --role-name ${ROLE_NAME} --permissions-boundary arn:aws:iam::${ACCOUNT_NUMBER}:policy/zsmce-tenantOperator-AMI-APIG --assume-role-policy-document file://U-CS_Service_Role_Trust_Policy.json --profile ${ACCOUNT_NAME} > role.txt
 cat role.txt
 ROLE_ARN=$(cat role.txt|jq -r '.Role.Arn')
 echo "Role ARN: $ROLE_ARN"

--- a/build/eksctl/eksctl-config.yaml
+++ b/build/eksctl/eksctl-config.yaml
@@ -18,9 +18,6 @@ managedNodeGroups:
     iam:
       instanceRoleARN: arn:aws:iam::237868187491:role/U-CS-AmazonEKSNodeRole
     privateNetworking: true
-    overrideBootstrapCommand: |
-      #!/bin/bash
-      /etc/eks/bootstrap.sh ucstestcluster3
 addons:
   - name: kube-proxy
     version: v1.21.2-eksbuild.2

--- a/build/terraform/main.tf
+++ b/build/terraform/main.tf
@@ -16,7 +16,7 @@ provider "aws" {
   shared_credentials_file = var.credentials
   profile = var.profile
 
-  ignore_tags {
+  ignore_tags = {
     key_prefixes = ["unity-cs-mcp"]
   }
 }

--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -103,7 +103,7 @@ Parameters:
   PrivilegedPolicyName:
     Description: Name of an existing IAM policy which allows privileged access to AWS services.
     Type: String
-    Default: smce-tenantOperator-AMI-APIG
+    Default: zsmce-tenantOperator-AMI-APIG
 
   GithubToken:
     Description: Github PAT with repo:read access. Used to clone repositories from https://github.com/unity-sds

--- a/cloudformation-template/unity-mc.main.template.yaml
+++ b/cloudformation-template/unity-mc.main.template.yaml
@@ -103,7 +103,7 @@ Parameters:
   PrivilegedPolicyName:
     Description: Name of an existing IAM policy which allows privileged access to AWS services.
     Type: String
-    Default: mcp-tenantOperator-AMI-APIG
+    Default: smce-tenantOperator-AMI-APIG
 
   GithubToken:
     Description: Github PAT with repo:read access. Used to clone repositories from https://github.com/unity-sds

--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -106,8 +106,8 @@ data "aws_iam_policy_document" "inline_policy" {
 }
 
 # The Policy for Permission Boundary
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "maap-spsdeploy"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 # IAM Role for Lambda Authorizer
@@ -118,7 +118,7 @@ resource "aws_iam_role" "iam_for_lambda_auth" {
     policy = data.aws_iam_policy_document.inline_policy.json
   }
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
 }
 
 # Unity CS Common Auth Lambda

--- a/terraform-project-api-gateway_module/main.tf
+++ b/terraform-project-api-gateway_module/main.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "inline_policy" {
 
 # The Policy for Permission Boundary
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+  name = "maap-spsdeploy"
 }
 
 # IAM Role for Lambda Authorizer

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -84,8 +84,8 @@ data "aws_iam_policy_document" "inline_policy" {
 }
 
 # The Policy for Permission Boundary
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "maap-spsdeploy"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 # IAM Role for Lambda Authorizer
@@ -96,7 +96,7 @@ resource "aws_iam_role" "iam_for_lambda_auth" {
     policy = data.aws_iam_policy_document.inline_policy.json
   }
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
 }
 
 # Unity CS Common Auth Lambda

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -1,7 +1,7 @@
-# REST API Gateway
+# Shared Services REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
-  name        = "unity-${var.project}-${var.venue}-rest-api-gateway"
-  description = "Unity ${var.project}-${var.venue} Project REST API Gateway"
+  name        = var.rest_api_name
+  description = var.rest_api_description
   endpoint_configuration {
     types = ["REGIONAL"]
   }
@@ -17,18 +17,18 @@ resource "aws_api_gateway_method" "root_level_options_method" {
 
 # REST API Gateway root level GET method mock integration
 resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_rest_api.rest_api.root_resource_id
-  http_method = aws_api_gateway_method.root_level_options_method.http_method
-  type        = "MOCK"
+  rest_api_id          = aws_api_gateway_rest_api.rest_api.id
+  resource_id          = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method          = aws_api_gateway_method.root_level_options_method.http_method
+  type                 = "MOCK"
 }
 
 # REST API ID SSM Param for other resources to modify rest api
 resource "aws_ssm_parameter" "api_gateway_rest_api_id_parameter" {
-  name       = format("/unity/cs/routing/api-gateway/rest-api-id-2")
+  name       = format("/unity/cs/routing/shared-services-api-gateway/rest-api-id")
   type       = "String"
-  overwrite  = true
   value      = aws_api_gateway_rest_api.rest_api.id
+  overwrite  = true
   depends_on = [aws_api_gateway_rest_api.rest_api]
 }
 
@@ -41,45 +41,23 @@ resource "null_resource" "download_lambda_zip" {
 
 # CloudWatch Log Group for Unity CS Common Auth Lambda
 resource "aws_cloudwatch_log_group" "cs_common_lambda_auth_log_group" {
-  name              = "/aws/lambda/${var.project}-${var.venue}-${var.unity_cs_lambda_authorizer_function_name}"
+  name              = "/aws/lambda/${var.unity_cs_lambda_authorizer_function_name}"
   retention_in_days = 14
 }
 
-resource "aws_ssm_parameter" "invoke_role_arn" {
-  name      = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
-  overwrite = true
-  type      = "String"
-  value     = aws_iam_role.iam_for_lambda_auth.arn
-}
-
-# Unity shared services account id
-data "aws_ssm_parameter" "shared_service_account_id" {
-  name = var.ssm_account_id
-}
-
-# Unity shared services account region
-data "aws_ssm_parameter" "shared_service_region" {
-  name = var.ssm_region
+# Unity CS Common Lambda Authorizer Allowed Cognito Client ID List (Command Seperated)
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list
 }
 
 # Unity CS Common Lambda Authorizer Allowed Cognito User Pool ID
 data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
-  name = "arn:aws:ssm:${data.aws_ssm_parameter.shared_service_region.value}:${data.aws_ssm_parameter.shared_service_account_id.value}:parameter/unity/shared-services/cognito/user-pool-id"
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id
 }
 
-# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Comma Seperated)
+# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Command Seperated)
 data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
-  name = "arn:aws:ssm:${data.aws_ssm_parameter.shared_service_region.value}:${data.aws_ssm_parameter.shared_service_account_id.value}:parameter/unity/shared-services/cognito/default-user-groups"
-}
-
-# Unity Management Console NLB
-data "aws_lb" "unity_mc_nlb" {
-  name = format("%s-%s-%s", var.unity_mc_nlb_name_prefix, var.project, var.venue)
-
-  tags = {
-    "Proj"  = var.project
-    "Venue" = var.venue
-  }
+  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
 }
 
 # IAM Policy Document for Assume Role
@@ -97,43 +75,43 @@ data "aws_iam_policy_document" "assume_role" {
 # IAM Policy Document for Inline Policy
 data "aws_iam_policy_document" "inline_policy" {
   statement {
-    actions = ["logs:CreateLogGroup",
+    actions   = ["logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-    "lambda:InvokeFunction"]
+      "lambda:InvokeFunction"]
     resources = ["*"]
   }
 }
 
 # The Policy for Permission Boundary
-data "aws_iam_policy" "mcp_operator_policy" {
+data "aws_iam_policy" "smce_operator_policy" {
   name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 # IAM Role for Lambda Authorizer
 resource "aws_iam_role" "iam_for_lambda_auth" {
-  name = "${var.project}-${var.venue}-iam_for_lambda_auth"
+  name = "iam_for_lambda_auth"
   inline_policy {
     name   = "unity-cs-lambda-auth-inline-policy"
     policy = data.aws_iam_policy_document.inline_policy.json
   }
-  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
 }
 
 # Unity CS Common Auth Lambda
 resource "aws_lambda_function" "cs_common_lambda_auth" {
   filename      = "ucs-common-lambda-auth.zip"
-  function_name = "${var.project}-${var.venue}-${var.unity_cs_lambda_authorizer_function_name}"
+  function_name = var.unity_cs_lambda_authorizer_function_name
   role          = aws_iam_role.iam_for_lambda_auth.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
-  depends_on    = [null_resource.download_lambda_zip]
+  runtime       = "nodejs14.x"
+  depends_on = [null_resource.download_lambda_zip, aws_cloudwatch_log_group.cs_common_lambda_auth_log_group]
 
   environment {
     variables = {
-      COGNITO_CLIENT_ID_LIST = "deprecated"
-      COGNITO_USER_POOL_ID   = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
+      COGNITO_CLIENT_ID_LIST = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_client_id_list.value
+      COGNITO_USER_POOL_ID = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
       COGNITO_GROUPS_ALLOWED = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_groups_list.value
     }
   }
@@ -141,106 +119,21 @@ resource "aws_lambda_function" "cs_common_lambda_auth" {
 
 # Unity CS Common Auth Lambda Authorizer (in API Gateway)
 resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
-  name                             = "Unity_CS_Common_Authorizer"
-  rest_api_id                      = aws_api_gateway_rest_api.rest_api.id
-  authorizer_uri                   = aws_lambda_function.cs_common_lambda_auth.invoke_arn
-  authorizer_credentials           = aws_iam_role.iam_for_lambda_auth.arn
-  authorizer_result_ttl_in_seconds = 0
-  identity_source                  = "method.request.header.Authorization"
-  depends_on                       = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
+  name                              = var.unity_cs_api_gateway_authorizer_name
+  rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
+  authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
+  authorizer_credentials            = aws_iam_role.iam_for_lambda_auth.arn
+  authorizer_result_ttl_in_seconds  = 0
+  identity_source                   = "method.request.header.Authorization"
+  depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
 }
-
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
 
 # API Gateway deployment
 resource "aws_api_gateway_deployment" "api-gateway-deployment" {
   rest_api_id = aws_api_gateway_rest_api.rest_api.id
   stage_name  = var.rest_api_stage
-  depends_on  = [aws_api_gateway_integration.rest_api_integration_for_health_check]
+  depends_on = [aws_api_gateway_integration.root_level_get_method_mock_integration]
 }
 
-resource "aws_ssm_parameter" "api_gateway_uri" {
-  name      = "/unity/cs/management/api-gateway/gateway-uri"
-  overwrite = true
-  type      = "String"
-  value     = "https://${aws_api_gateway_rest_api.rest_api.id}.execute-api.${data.aws_ssm_parameter.shared_service_region.value}.amazonaws.com/${aws_api_gateway_stage.api_gateway_stage.stage_name}"
-}
-
-# Management Console Health Check API Integration Code
-resource "aws_api_gateway_resource" "rest_api_resource_management_path" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  parent_id   = aws_api_gateway_rest_api.rest_api.root_resource_id
-  path_part   = "management"
-}
-
-resource "aws_api_gateway_resource" "rest_api_resource_api_path" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  parent_id   = aws_api_gateway_resource.rest_api_resource_management_path.id
-  path_part   = "api"
-}
-
-resource "aws_api_gateway_resource" "rest_api_resource_health_checks_path" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  parent_id   = aws_api_gateway_resource.rest_api_resource_api_path.id
-  path_part   = "health_checks"
-}
-
-resource "aws_api_gateway_method" "rest_api_method_for_health_check_method" {
-  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
-  resource_id   = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
-  http_method   = "GET"
-  authorization = "CUSTOM"
-  authorizer_id = aws_api_gateway_authorizer.unity_cs_common_authorizer.id
-}
-
-resource "aws_api_gateway_vpc_link" "rest_api_health_check_vpc_link" {
-  name        = "mc-nlb-vpc-link-${var.project}-${var.venue}"
-  description = "mc-nlb-vpc-link-${var.project}-${var.venue}"
-  target_arns = [data.aws_lb.unity_mc_nlb.arn]
-}
-
-resource "aws_api_gateway_integration" "rest_api_integration_for_health_check" {
-  rest_api_id             = aws_api_gateway_rest_api.rest_api.id
-  resource_id             = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
-  http_method             = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
-  type                    = "HTTP"
-  uri                     = format("%s://%s:%s", "http", data.aws_lb.unity_mc_nlb.dns_name, "8080/api/health_checks")
-  integration_http_method = "GET"
-  passthrough_behavior    = "WHEN_NO_TEMPLATES"
-  content_handling        = "CONVERT_TO_TEXT"
-  connection_type         = "VPC_LINK"
-  connection_id           = aws_api_gateway_vpc_link.rest_api_health_check_vpc_link.id
-
-  depends_on              = [aws_api_gateway_vpc_link.rest_api_health_check_vpc_link]
-}
-
-resource "aws_api_gateway_method_response" "response_200" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
-  http_method = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
-  status_code = "200"
-
-  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
-}
-
-resource "aws_api_gateway_integration_response" "api_gateway_integration_response" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  resource_id = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
-  http_method = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
-  status_code = aws_api_gateway_method_response.response_200.status_code
-
-  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
-}
-
-resource "aws_api_gateway_stage" "api_gateway_stage" {
-  deployment_id = aws_api_gateway_deployment.api-gateway-deployment.id
-  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
-  stage_name    = "default"
-
-  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
-}
-
-output "unity_venue_level_api_gateway_rest_api_id" {
-  value = aws_api_gateway_rest_api.rest_api.id
-}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "inline_policy" {
 
 # The Policy for Permission Boundary
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "maap-spsdeploy"
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 # IAM Role for Lambda Authorizer

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -1,720 +1,246 @@
-resource "aws_iam_role" "cluster_iam_role" {
-  name = "${local.cluster_name}-eks-node-role"
+# REST API Gateway
+resource "aws_api_gateway_rest_api" "rest_api" {
+  name        = "unity-${var.project}-${var.venue}-rest-api-gateway"
+  description = "Unity ${var.project}-${var.venue} Project REST API Gateway"
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "eks.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "ec2.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "s3.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-    ],
-  })
+# REST API Gateway root level OPTIONS method (to allow deployment with at least one method)
+resource "aws_api_gateway_method" "root_level_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
+  resource_id   = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
 
+# REST API Gateway root level GET method mock integration
+resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  resource_id = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method = aws_api_gateway_method.root_level_options_method.http_method
+  type        = "MOCK"
+}
+
+# REST API ID SSM Param for other resources to modify rest api
+resource "aws_ssm_parameter" "api_gateway_rest_api_id_parameter" {
+  name       = format("/unity/cs/routing/api-gateway/rest-api-id-2")
+  type       = "String"
+  overwrite  = true
+  value      = aws_api_gateway_rest_api.rest_api.id
+  depends_on = [aws_api_gateway_rest_api.rest_api]
+}
+
+# Download the Unity CS Common Auth Lambda deployment zip file
+resource "null_resource" "download_lambda_zip" {
+  provisioner "local-exec" {
+    command = "wget --no-check-certificate ${var.unity_cs_lambda_authorizer_zip_path}  -O ucs-common-lambda-auth.zip"
+  }
+}
+
+# CloudWatch Log Group for Unity CS Common Auth Lambda
+resource "aws_cloudwatch_log_group" "cs_common_lambda_auth_log_group" {
+  name              = "/aws/lambda/${var.project}-${var.venue}-${var.unity_cs_lambda_authorizer_function_name}"
+  retention_in_days = 14
+}
+
+resource "aws_ssm_parameter" "invoke_role_arn" {
+  name      = var.ssm_param_api_gateway_cs_lambda_authorizer_invoke_role_arn
+  overwrite = true
+  type      = "String"
+  value     = aws_iam_role.iam_for_lambda_auth.arn
+}
+
+# Unity shared services account id
+data "aws_ssm_parameter" "shared_service_account_id" {
+  name = var.ssm_account_id
+}
+
+# Unity shared services account region
+data "aws_ssm_parameter" "shared_service_region" {
+  name = var.ssm_region
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito User Pool ID
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
+  name = "arn:aws:ssm:${data.aws_ssm_parameter.shared_service_region.value}:${data.aws_ssm_parameter.shared_service_account_id.value}:parameter/unity/shared-services/cognito/user-pool-id"
+}
+
+# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Comma Seperated)
+data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
+  name = "arn:aws:ssm:${data.aws_ssm_parameter.shared_service_region.value}:${data.aws_ssm_parameter.shared_service_account_id.value}:parameter/unity/shared-services/cognito/default-user-groups"
+}
+
+# Unity Management Console NLB
+data "aws_lb" "unity_mc_nlb" {
+  name = format("%s-%s-%s", var.unity_mc_nlb_name_prefix, var.project, var.venue)
+
+  tags = {
+    "Proj"  = var.project
+    "Venue" = var.venue
+  }
+}
+
+# IAM Policy Document for Assume Role
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# IAM Policy Document for Inline Policy
+data "aws_iam_policy_document" "inline_policy" {
+  statement {
+    actions = ["logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    "lambda:InvokeFunction"]
+    resources = ["*"]
+  }
+}
+
+# The Policy for Permission Boundary
+data "aws_iam_policy" "mcp_operator_policy" {
+  name = "maap-spsdeploy"
+}
+
+# IAM Role for Lambda Authorizer
+resource "aws_iam_role" "iam_for_lambda_auth" {
+  name = "${var.project}-${var.venue}-iam_for_lambda_auth"
+  inline_policy {
+    name   = "unity-cs-lambda-auth-inline-policy"
+    policy = data.aws_iam_policy_document.inline_policy.json
+  }
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
-
 }
 
-resource "aws_iam_role_policy_attachment" "container-reg" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
+# Unity CS Common Auth Lambda
+resource "aws_lambda_function" "cs_common_lambda_auth" {
+  filename      = "ucs-common-lambda-auth.zip"
+  function_name = "${var.project}-${var.venue}-${var.unity_cs_lambda_authorizer_function_name}"
+  role          = aws_iam_role.iam_for_lambda_auth.arn
+  handler       = "index.handler"
+  runtime       = "nodejs20.x"
+  depends_on    = [null_resource.download_lambda_zip]
 
-resource "aws_iam_role_policy_attachment" "ebscsi" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-}
-resource "aws_iam_role_policy_attachment" "eks-cni" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-}
-resource "aws_iam_role_policy_attachment" "worker-node" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-}
-resource "aws_iam_role_policy_attachment" "ssm-automation" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
-}
-resource "aws_iam_role_policy_attachment" "ssm-managed-instance" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
-}
-
-
-resource "aws_iam_role_policy_attachment" "node-policy" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = aws_iam_policy.custom_policy.arn
-}
-
-resource "aws_iam_policy" "custom_policy" {
-  name        = "${local.cluster_name}-eks-policy" # Give a unique name to your policy
-  path        = "/"                                # Optionally, specify a path for the policy
-  description = "A custom policy that provides access to EC2, ECR, SNS, etc."
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": "ec2:CreateTags",
-            "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": [
-                        "CreateVolume",
-                        "CreateSnapshot"
-                    ]
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor1",
-            "Effect": "Allow",
-            "Action": "ec2:CreateVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor2",
-            "Effect": "Allow",
-            "Action": "ec2:CreateVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "aws:RequestTag/CSIVolumeName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor3",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor4",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/CSIVolumeName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor5",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor6",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteSnapshot",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor7",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteSnapshot",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor8",
-            "Effect": "Allow",
-            "Action": "ec2:CreateTags",
-            "Resource": "arn:aws:ec2:*:*:network-interface/*"
-        },
-        {
-            "Sid": "VisualEditor9",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteTags",
-            "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
-            ]
-        },
-        {
-            "Sid": "VisualEditor10",
-            "Effect": "Allow",
-            "Action": [
-                "sns:Publish",
-                "lambda:InvokeFunction",
-                "ssm:GetParameter"
-            ],
-            "Resource": [
-                "arn:aws:lambda:*:*:function:Automation*",
-                "arn:aws:sns:*:*:Automation*",
-                "arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:GetAuthorizationToken",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:GetRepositoryPolicy",
-                "ecr:DescribeRepositories",
-                "ecr:ListImages",
-                "ecr:DescribeImages",
-                "ecr:BatchGetImage",
-                "ecr:GetLifecyclePolicy",
-                "ecr:GetLifecyclePolicyPreview",
-                "ecr:ListTagsForResource",
-                "ecr:DescribeImageScanFindings"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "VisualEditor11",
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeInstances",
-                "cloudwatch:PutMetricData",
-                "ec2:DescribeVolumesModifications",
-                "ec2:CreateImage",
-                "ec2:CopyImage",
-                "ssm:ListInstanceAssociations",
-                "ec2:DescribeSnapshots",
-                "ssm:GetParameter",
-                "ssm:UpdateAssociationStatus",
-                "logs:CreateLogStream",
-                "cloudformation:DescribeStackEvents",
-                "ec2:StartInstances",
-                "ssm:UpdateInstanceInformation",
-                "ec2:DescribeVolumes",
-                "cloudformation:UpdateStack",
-                "ec2:UnassignPrivateIpAddresses",
-                "ec2:DescribeRouteTables",
-                "ssm:PutComplianceItems",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetLifecyclePolicy",
-                "ec2:DetachVolume",
-                "sns:*",
-                "ec2:ModifyVolume",
-                "ecr:DescribeImageScanFindings",
-                "ec2:CreateTags",
-                "ec2:ModifyNetworkInterfaceAttribute",
-                "ecr:GetDownloadUrlForLayer",
-                "ec2:DeleteNetworkInterface",
-                "ec2messages:AcknowledgeMessage",
-                "ec2:RunInstances",
-                "ecr:GetAuthorizationToken",
-                "ssm:GetParameters",
-                "ec2:StopInstances",
-                "s3-object-lambda:*",
-                "ec2:AssignPrivateIpAddresses",
-                "logs:CreateLogGroup",
-                "cloudformation:DescribeStacks",
-                "ec2:CreateNetworkInterface",
-                "cloudformation:DeleteStack",
-                "ec2:DescribeInstanceTypes",
-                "ecr:BatchGetImage",
-                "ecr:DescribeImages",
-                "ec2messages:SendReply",
-                "eks:DescribeCluster",
-                "ec2:DescribeSubnets",
-                "ec2:AttachVolume",
-                "ec2:DeregisterImage",
-                "ec2:DeleteSnapshot",
-                "ssm:DescribeDocument",
-                "ec2:DeleteTags",
-                "ec2messages:GetEndpoint",
-                "logs:DescribeLogStreams",
-                "ssmmessages:OpenControlChannel",
-                "ec2messages:GetMessages",
-                "ecr:ListTagsForResource",
-                "ssm:PutConfigurePackageResult",
-                "ecr:ListImages",
-                "ssm:GetManifest",
-                "ec2messages:DeleteMessage",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2messages:FailMessage",
-                "ec2:DescribeAvailabilityZones",
-                "ssmmessages:OpenDataChannel",
-                "ec2:CreateSnapshot",
-                "ssm:GetDocument",
-                "ecr:DescribeRepositories",
-                "ec2:DescribeInstanceStatus",
-                "ssm:DescribeAssociation",
-                "ec2:TerminateInstances",
-                "ec2:DetachNetworkInterface",
-                "logs:DescribeLogGroups",
-                "ssm:GetDeployablePatchSnapshotForInstance",
-                "s3:*",
-                "ec2:DescribeTags",
-                "ecr:GetLifecyclePolicyPreview",
-                "ssmmessages:CreateControlChannel",
-                "logs:PutLogEvents",
-                "ec2:DescribeSecurityGroups",
-                "ssmmessages:CreateDataChannel",
-                "ec2:DescribeImages",
-                "ssm:PutInventory",
-                "cloudformation:CreateStack",
-                "ec2:DescribeVpcs",
-                "ssm:*",
-                "ec2:AttachNetworkInterface",
-                "ssm:ListAssociations",
-                "ssm:UpdateInstanceAssociationStatus",
-                "ecr:GetRepositoryPolicy"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
-
-module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "19.16.0"
-
-  cluster_name    = local.cluster_name
-  cluster_version = var.cluster_version
-
-  cluster_addons = {
-    coredns = {
-      most_recent = true
-    }
-    kube-proxy = {
-      most_recent = true
-    }
-    vpc-cni = {
-      most_recent = true
-    }
-    aws-ebs-csi-driver = {
-      most_recent = true
-      configuration_values = jsonencode({
-        defaultStorageClass = {
-          enabled = true
-        }
-      })
-    }
-    aws-efs-csi-driver = {
-      most_recent = true
-    }
-  }
-
-  subnet_ids = local.subnet_map["private"]
-
-  vpc_id = data.aws_ssm_parameter.vpc_id.value
-
-  #cluster_security_group_id = data.aws_ssm_parameter.cluster_sg.value
-  create_cluster_security_group         = true
-  create_node_security_group            = true
-  cluster_additional_security_group_ids = [aws_security_group.mc_ingress_sg.id]
-  create_iam_role                       = false
-  enable_irsa                           = true
-  iam_role_arn                          = aws_iam_role.cluster_iam_role.arn
-  #node_security_group_id = data.aws_ssm_parameter.node_sg.value
-
-  eks_managed_node_group_defaults = {
-    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-    iam_role_arn   = aws_iam_role.cluster_iam_role.arn
-  }
-
-  eks_managed_node_groups = local.mergednodegroups
-
-  aws_auth_roles                  = var.aws_auth_roles
-  cluster_endpoint_private_access = true
-  cluster_endpoint_public_access  = true
-  tags                            = var.tags
-}
-
-resource "aws_security_group" "mc_ingress_sg" {
-  name        = "${var.project}-${var.venue}-mc-ingress-sg"
-  description = "SecurityGroup for management console ingress"
-  vpc_id      = data.aws_ssm_parameter.vpc_id.value
-}
-
-resource "aws_vpc_security_group_ingress_rule" "mc_ingress_rule" {
-  count                        = length(data.aws_security_groups.mc_sg.ids) > 0 ? 1 : 0
-  security_group_id            = aws_security_group.mc_ingress_sg.id
-  description                  = "SecurityGroup ingress rule for management console"
-  ip_protocol                  = -1
-  referenced_security_group_id = data.aws_security_groups.mc_sg.ids[0]
-}
-
-# TODO: select default node group more intelligently, or remove concept altogether
-resource "aws_ssm_parameter" "node_group_default_name" {
-  name = "/unity/extensions/eks/${var.deployment_name}/nodeGroups/default/name"
-  type = "String"
-  # Get name of first nodegroup in nodegroup map variable
-  value = keys(var.nodegroups)[0]
-  # Get first nodegroup name from keys of node group variable and use it to
-  # value = split(":", aws_eks_node_group.node_groups[keys(var.node_groups)[0]].id)[0]
-}
-
-resource "aws_ssm_parameter" "eks_subnets" {
-  name  = "/unity/extensions/eks/${local.cluster_name}/networking/subnets/publicIds"
-  type  = "String"
-  value = join(",", local.subnet_map["private"])
-}
-
-resource "helm_release" "aws-load-balancer-controller" {
-  name       = "aws-load-balancer-controller"
-  repository = "https://aws.github.io/eks-charts"
-  chart      = "aws-load-balancer-controller"
-  version    = "1.6.1"
-  namespace  = "kube-system"
-  set = [
-    {
-      name  = "clusterName"
-      value = module.eks.cluster_name
-    },
-    {
-      name  = "serviceAccount.create"
-      value = "false"
-    },
-    {
-      name  = "serviceAccount.name"
-      value = "aws-load-balancer-controller"
-    }
-  ]
-
-  depends_on = [module.eks.eks_managed_node_groups]
-}
-
-resource "kubernetes_service_account" "aws-load-balancer-controller-service-account" {
-  metadata {
-    name      = "aws-load-balancer-controller"
-    namespace = "kube-system"
-    annotations = {
-      "eks.amazonaws.com/role-arn" : aws_iam_role.aws-load-balancer-controller-role.arn
-    }
-    labels = {
-      "app.kubernetes.io/component" : "controller"
-      "app.kubernetes.io/name" : "aws-load-balancer-controller"
+  environment {
+    variables = {
+      COGNITO_CLIENT_ID_LIST = "deprecated"
+      COGNITO_USER_POOL_ID   = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
+      COGNITO_GROUPS_ALLOWED = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_groups_list.value
     }
   }
 }
 
-# AwsLoadBalancerController Role and Policy from https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
-resource "aws_iam_role" "aws-load-balancer-controller-role" {
-  name = "AwsLoadBalancerControllerRole-${local.cluster_name}"
-
-  assume_role_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Principal" : {
-          "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
-        },
-        "Action" : "sts:AssumeRoleWithWebIdentity",
-        "Condition" : {
-          "StringEquals" : {
-            "${local.openidc_provider_domain_name}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller",
-            "${local.openidc_provider_domain_name}:aud" : "sts.amazonaws.com"
-          }
-        }
-      }
-    ]
-  })
-
-  managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/zsmce-tenantOperator-AMI-APIG"
+# Unity CS Common Auth Lambda Authorizer (in API Gateway)
+resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
+  name                             = "Unity_CS_Common_Authorizer"
+  rest_api_id                      = aws_api_gateway_rest_api.rest_api.id
+  authorizer_uri                   = aws_lambda_function.cs_common_lambda_auth.invoke_arn
+  authorizer_credentials           = aws_iam_role.iam_for_lambda_auth.arn
+  authorizer_result_ttl_in_seconds = 0
+  identity_source                  = "method.request.header.Authorization"
+  depends_on                       = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
 }
 
-resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {
-  role       = aws_iam_role.aws-load-balancer-controller-role.name
-  policy_arn = data.aws_iam_policy.aws-managed-load-balancer-policy.arn
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# API Gateway deployment
+resource "aws_api_gateway_deployment" "api-gateway-deployment" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  stage_name  = var.rest_api_stage
+  depends_on  = [aws_api_gateway_integration.rest_api_integration_for_health_check]
 }
 
-resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
-  name = "AwsLoadBalancerControllerPolicy-${local.cluster_name}"
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "iam:CreateServiceLinkedRole"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "StringEquals" : {
-            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:DescribeAccountAttributes",
-          "ec2:DescribeAddresses",
-          "ec2:DescribeAvailabilityZones",
-          "ec2:DescribeInternetGateways",
-          "ec2:DescribeVpcs",
-          "ec2:DescribeVpcPeeringConnections",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeSecurityGroups",
-          "ec2:DescribeInstances",
-          "ec2:DescribeNetworkInterfaces",
-          "ec2:DescribeTags",
-          "ec2:GetCoipPoolUsage",
-          "ec2:DescribeCoipPools",
-          "elasticloadbalancing:DescribeLoadBalancers",
-          "elasticloadbalancing:DescribeLoadBalancerAttributes",
-          "elasticloadbalancing:DescribeListeners",
-          "elasticloadbalancing:DescribeListenerCertificates",
-          "elasticloadbalancing:DescribeSSLPolicies",
-          "elasticloadbalancing:DescribeRules",
-          "elasticloadbalancing:DescribeTargetGroups",
-          "elasticloadbalancing:DescribeTargetGroupAttributes",
-          "elasticloadbalancing:DescribeTargetHealth",
-          "elasticloadbalancing:DescribeTags"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "cognito-idp:DescribeUserPoolClient",
-          "acm:ListCertificates",
-          "acm:DescribeCertificate",
-          "iam:ListServerCertificates",
-          "iam:GetServerCertificate",
-          "waf-regional:GetWebACL",
-          "waf-regional:GetWebACLForResource",
-          "waf-regional:AssociateWebACL",
-          "waf-regional:DisassociateWebACL",
-          "wafv2:GetWebACL",
-          "wafv2:GetWebACLForResource",
-          "wafv2:AssociateWebACL",
-          "wafv2:DisassociateWebACL",
-          "shield:GetSubscriptionState",
-          "shield:DescribeProtection",
-          "shield:CreateProtection",
-          "shield:DeleteProtection"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateSecurityGroup"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateTags"
-        ],
-        "Resource" : "arn:aws:ec2:*:*:security-group/*",
-        "Condition" : {
-          "StringEquals" : {
-            "ec2:CreateAction" : "CreateSecurityGroup"
-          },
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:CreateTags",
-          "ec2:DeleteTags"
-        ],
-        "Resource" : "arn:aws:ec2:*:*:security-group/*",
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:DeleteSecurityGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:CreateLoadBalancer",
-          "elasticloadbalancing:CreateTargetGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:CreateListener",
-          "elasticloadbalancing:DeleteListener",
-          "elasticloadbalancing:CreateRule",
-          "elasticloadbalancing:DeleteRule"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags",
-          "elasticloadbalancing:RemoveTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ],
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags",
-          "elasticloadbalancing:RemoveTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:ModifyLoadBalancerAttributes",
-          "elasticloadbalancing:SetIpAddressType",
-          "elasticloadbalancing:SetSecurityGroups",
-          "elasticloadbalancing:SetSubnets",
-          "elasticloadbalancing:DeleteLoadBalancer",
-          "elasticloadbalancing:ModifyTargetGroup",
-          "elasticloadbalancing:ModifyTargetGroupAttributes",
-          "elasticloadbalancing:DeleteTargetGroup"
-        ],
-        "Resource" : "*",
-        "Condition" : {
-          "Null" : {
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:AddTags"
-        ],
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "elasticloadbalancing:CreateAction" : [
-              "CreateTargetGroup",
-              "CreateLoadBalancer"
-            ]
-          },
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:RegisterTargets",
-          "elasticloadbalancing:DeregisterTargets"
-        ],
-        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "elasticloadbalancing:SetWebAcl",
-          "elasticloadbalancing:ModifyListener",
-          "elasticloadbalancing:AddListenerCertificates",
-          "elasticloadbalancing:RemoveListenerCertificates",
-          "elasticloadbalancing:ModifyRule"
-        ],
-        "Resource" : "*"
-      }
-    ]
-  })
+resource "aws_ssm_parameter" "api_gateway_uri" {
+  name      = "/unity/cs/management/api-gateway/gateway-uri"
+  overwrite = true
+  type      = "String"
+  value     = "https://${aws_api_gateway_rest_api.rest_api.id}.execute-api.${data.aws_ssm_parameter.shared_service_region.value}.amazonaws.com/${aws_api_gateway_stage.api_gateway_stage.stage_name}"
+}
+
+# Management Console Health Check API Integration Code
+resource "aws_api_gateway_resource" "rest_api_resource_management_path" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  parent_id   = aws_api_gateway_rest_api.rest_api.root_resource_id
+  path_part   = "management"
+}
+
+resource "aws_api_gateway_resource" "rest_api_resource_api_path" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  parent_id   = aws_api_gateway_resource.rest_api_resource_management_path.id
+  path_part   = "api"
+}
+
+resource "aws_api_gateway_resource" "rest_api_resource_health_checks_path" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  parent_id   = aws_api_gateway_resource.rest_api_resource_api_path.id
+  path_part   = "health_checks"
+}
+
+resource "aws_api_gateway_method" "rest_api_method_for_health_check_method" {
+  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
+  resource_id   = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
+  http_method   = "GET"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.unity_cs_common_authorizer.id
+}
+
+resource "aws_api_gateway_vpc_link" "rest_api_health_check_vpc_link" {
+  name        = "mc-nlb-vpc-link-${var.project}-${var.venue}"
+  description = "mc-nlb-vpc-link-${var.project}-${var.venue}"
+  target_arns = [data.aws_lb.unity_mc_nlb.arn]
+}
+
+resource "aws_api_gateway_integration" "rest_api_integration_for_health_check" {
+  rest_api_id             = aws_api_gateway_rest_api.rest_api.id
+  resource_id             = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
+  http_method             = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
+  type                    = "HTTP"
+  uri                     = format("%s://%s:%s", "http", data.aws_lb.unity_mc_nlb.dns_name, "8080/api/health_checks")
+  integration_http_method = "GET"
+  passthrough_behavior    = "WHEN_NO_TEMPLATES"
+  content_handling        = "CONVERT_TO_TEXT"
+  connection_type         = "VPC_LINK"
+  connection_id           = aws_api_gateway_vpc_link.rest_api_health_check_vpc_link.id
+
+  depends_on              = [aws_api_gateway_vpc_link.rest_api_health_check_vpc_link]
+}
+
+resource "aws_api_gateway_method_response" "response_200" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  resource_id = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
+  http_method = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
+  status_code = "200"
+
+  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
+}
+
+resource "aws_api_gateway_integration_response" "api_gateway_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  resource_id = aws_api_gateway_resource.rest_api_resource_health_checks_path.id
+  http_method = aws_api_gateway_method.rest_api_method_for_health_check_method.http_method
+  status_code = aws_api_gateway_method_response.response_200.status_code
+
+  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
+}
+
+resource "aws_api_gateway_stage" "api_gateway_stage" {
+  deployment_id = aws_api_gateway_deployment.api-gateway-deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
+  stage_name    = "default"
+
+  depends_on = [aws_api_gateway_integration.rest_api_integration_for_health_check]
+}
+
+output "unity_venue_level_api_gateway_rest_api_id" {
+  value = aws_api_gateway_rest_api.rest_api.id
 }

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -1,139 +1,720 @@
-# Shared Services REST API Gateway
-resource "aws_api_gateway_rest_api" "rest_api" {
-  name        = var.rest_api_name
-  description = var.rest_api_description
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
+resource "aws_iam_role" "cluster_iam_role" {
+  name = "${local.cluster_name}-eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "eks.amazonaws.com" # or the appropriate AWS service
+        },
+      },
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com" # or the appropriate AWS service
+        },
+      },
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "s3.amazonaws.com" # or the appropriate AWS service
+        },
+      },
+    ],
+  })
+
+  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+
 }
 
-# REST API Gateway root level OPTIONS method (to allow deployment with at least one method)
-resource "aws_api_gateway_method" "root_level_options_method" {
-  rest_api_id   = aws_api_gateway_rest_api.rest_api.id
-  resource_id   = aws_api_gateway_rest_api.rest_api.root_resource_id
-  http_method   = "OPTIONS"
-  authorization = "NONE"
+resource "aws_iam_role_policy_attachment" "container-reg" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
-# REST API Gateway root level GET method mock integration
-resource "aws_api_gateway_integration" "root_level_get_method_mock_integration" {
-  rest_api_id          = aws_api_gateway_rest_api.rest_api.id
-  resource_id          = aws_api_gateway_rest_api.rest_api.root_resource_id
-  http_method          = aws_api_gateway_method.root_level_options_method.http_method
-  type                 = "MOCK"
+resource "aws_iam_role_policy_attachment" "ebscsi" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+resource "aws_iam_role_policy_attachment" "eks-cni" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+resource "aws_iam_role_policy_attachment" "worker-node" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+resource "aws_iam_role_policy_attachment" "ssm-automation" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
+}
+resource "aws_iam_role_policy_attachment" "ssm-managed-instance" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
-# REST API ID SSM Param for other resources to modify rest api
-resource "aws_ssm_parameter" "api_gateway_rest_api_id_parameter" {
-  name       = format("/unity/cs/routing/shared-services-api-gateway/rest-api-id")
-  type       = "String"
-  value      = aws_api_gateway_rest_api.rest_api.id
-  overwrite  = true
-  depends_on = [aws_api_gateway_rest_api.rest_api]
+
+resource "aws_iam_role_policy_attachment" "node-policy" {
+  role       = aws_iam_role.cluster_iam_role.name
+  policy_arn = aws_iam_policy.custom_policy.arn
 }
 
-# Download the Unity CS Common Auth Lambda deployment zip file
-resource "null_resource" "download_lambda_zip" {
-  provisioner "local-exec" {
-    command = "wget --no-check-certificate ${var.unity_cs_lambda_authorizer_zip_path}  -O ucs-common-lambda-auth.zip"
-  }
+resource "aws_iam_policy" "custom_policy" {
+  name        = "${local.cluster_name}-eks-policy" # Give a unique name to your policy
+  path        = "/"                                # Optionally, specify a path for the policy
+  description = "A custom policy that provides access to EC2, ECR, SNS, etc."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:snapshot/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": [
+                        "CreateVolume",
+                        "CreateSnapshot"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "ec2:CreateVolume",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor2",
+            "Effect": "Allow",
+            "Action": "ec2:CreateVolume",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "aws:RequestTag/CSIVolumeName": "*"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor3",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteVolume",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor4",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteVolume",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/CSIVolumeName": "*"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor5",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteVolume",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor6",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteSnapshot",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor7",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteSnapshot",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor8",
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": "arn:aws:ec2:*:*:network-interface/*"
+        },
+        {
+            "Sid": "VisualEditor9",
+            "Effect": "Allow",
+            "Action": "ec2:DeleteTags",
+            "Resource": [
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:snapshot/*"
+            ]
+        },
+        {
+            "Sid": "VisualEditor10",
+            "Effect": "Allow",
+            "Action": [
+                "sns:Publish",
+                "lambda:InvokeFunction",
+                "ssm:GetParameter"
+            ],
+            "Resource": [
+                "arn:aws:lambda:*:*:function:Automation*",
+                "arn:aws:sns:*:*:Automation*",
+                "arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:DescribeImages",
+                "ecr:BatchGetImage",
+                "ecr:GetLifecyclePolicy",
+                "ecr:GetLifecyclePolicyPreview",
+                "ecr:ListTagsForResource",
+                "ecr:DescribeImageScanFindings"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor11",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "cloudwatch:PutMetricData",
+                "ec2:DescribeVolumesModifications",
+                "ec2:CreateImage",
+                "ec2:CopyImage",
+                "ssm:ListInstanceAssociations",
+                "ec2:DescribeSnapshots",
+                "ssm:GetParameter",
+                "ssm:UpdateAssociationStatus",
+                "logs:CreateLogStream",
+                "cloudformation:DescribeStackEvents",
+                "ec2:StartInstances",
+                "ssm:UpdateInstanceInformation",
+                "ec2:DescribeVolumes",
+                "cloudformation:UpdateStack",
+                "ec2:UnassignPrivateIpAddresses",
+                "ec2:DescribeRouteTables",
+                "ssm:PutComplianceItems",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetLifecyclePolicy",
+                "ec2:DetachVolume",
+                "sns:*",
+                "ec2:ModifyVolume",
+                "ecr:DescribeImageScanFindings",
+                "ec2:CreateTags",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ecr:GetDownloadUrlForLayer",
+                "ec2:DeleteNetworkInterface",
+                "ec2messages:AcknowledgeMessage",
+                "ec2:RunInstances",
+                "ecr:GetAuthorizationToken",
+                "ssm:GetParameters",
+                "ec2:StopInstances",
+                "s3-object-lambda:*",
+                "ec2:AssignPrivateIpAddresses",
+                "logs:CreateLogGroup",
+                "cloudformation:DescribeStacks",
+                "ec2:CreateNetworkInterface",
+                "cloudformation:DeleteStack",
+                "ec2:DescribeInstanceTypes",
+                "ecr:BatchGetImage",
+                "ecr:DescribeImages",
+                "ec2messages:SendReply",
+                "eks:DescribeCluster",
+                "ec2:DescribeSubnets",
+                "ec2:AttachVolume",
+                "ec2:DeregisterImage",
+                "ec2:DeleteSnapshot",
+                "ssm:DescribeDocument",
+                "ec2:DeleteTags",
+                "ec2messages:GetEndpoint",
+                "logs:DescribeLogStreams",
+                "ssmmessages:OpenControlChannel",
+                "ec2messages:GetMessages",
+                "ecr:ListTagsForResource",
+                "ssm:PutConfigurePackageResult",
+                "ecr:ListImages",
+                "ssm:GetManifest",
+                "ec2messages:DeleteMessage",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2messages:FailMessage",
+                "ec2:DescribeAvailabilityZones",
+                "ssmmessages:OpenDataChannel",
+                "ec2:CreateSnapshot",
+                "ssm:GetDocument",
+                "ecr:DescribeRepositories",
+                "ec2:DescribeInstanceStatus",
+                "ssm:DescribeAssociation",
+                "ec2:TerminateInstances",
+                "ec2:DetachNetworkInterface",
+                "logs:DescribeLogGroups",
+                "ssm:GetDeployablePatchSnapshotForInstance",
+                "s3:*",
+                "ec2:DescribeTags",
+                "ecr:GetLifecyclePolicyPreview",
+                "ssmmessages:CreateControlChannel",
+                "logs:PutLogEvents",
+                "ec2:DescribeSecurityGroups",
+                "ssmmessages:CreateDataChannel",
+                "ec2:DescribeImages",
+                "ssm:PutInventory",
+                "cloudformation:CreateStack",
+                "ec2:DescribeVpcs",
+                "ssm:*",
+                "ec2:AttachNetworkInterface",
+                "ssm:ListAssociations",
+                "ssm:UpdateInstanceAssociationStatus",
+                "ecr:GetRepositoryPolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
 }
 
-# CloudWatch Log Group for Unity CS Common Auth Lambda
-resource "aws_cloudwatch_log_group" "cs_common_lambda_auth_log_group" {
-  name              = "/aws/lambda/${var.unity_cs_lambda_authorizer_function_name}"
-  retention_in_days = 14
-}
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.16.0"
 
-# Unity CS Common Lambda Authorizer Allowed Cognito Client ID List (Command Seperated)
-data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_client_id_list" {
-  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_client_id_list
-}
+  cluster_name    = local.cluster_name
+  cluster_version = var.cluster_version
 
-# Unity CS Common Lambda Authorizer Allowed Cognito User Pool ID
-data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_pool_id" {
-  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_pool_id
-}
-
-# Unity CS Common Lambda Authorizer Allowed Cognito User Groups List (Command Seperated)
-data "aws_ssm_parameter" "api_gateway_cs_lambda_authorizer_cognito_user_groups_list" {
-  name = var.ssm_param_api_gateway_cs_lambda_authorizer_cognito_user_groups_list
-}
-
-# IAM Policy Document for Assume Role
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
+  cluster_addons = {
+    coredns = {
+      most_recent = true
     }
-    actions = ["sts:AssumeRole"]
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    aws-ebs-csi-driver = {
+      most_recent = true
+      configuration_values = jsonencode({
+        defaultStorageClass = {
+          enabled = true
+        }
+      })
+    }
+    aws-efs-csi-driver = {
+      most_recent = true
+    }
   }
-}
 
-# IAM Policy Document for Inline Policy
-data "aws_iam_policy_document" "inline_policy" {
-  statement {
-    actions   = ["logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "lambda:InvokeFunction"]
-    resources = ["*"]
+  subnet_ids = local.subnet_map["private"]
+
+  vpc_id = data.aws_ssm_parameter.vpc_id.value
+
+  #cluster_security_group_id = data.aws_ssm_parameter.cluster_sg.value
+  create_cluster_security_group         = true
+  create_node_security_group            = true
+  cluster_additional_security_group_ids = [aws_security_group.mc_ingress_sg.id]
+  create_iam_role                       = false
+  enable_irsa                           = true
+  iam_role_arn                          = aws_iam_role.cluster_iam_role.arn
+  #node_security_group_id = data.aws_ssm_parameter.node_sg.value
+
+  eks_managed_node_group_defaults = {
+    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+    iam_role_arn   = aws_iam_role.cluster_iam_role.arn
   }
+
+  eks_managed_node_groups = local.mergednodegroups
+
+  aws_auth_roles                  = var.aws_auth_roles
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+  tags                            = var.tags
 }
 
-# The Policy for Permission Boundary
-data "aws_iam_policy" "smce_operator_policy" {
-  name = "zsmce-tenantOperator-AMI-APIG"
+resource "aws_security_group" "mc_ingress_sg" {
+  name        = "${var.project}-${var.venue}-mc-ingress-sg"
+  description = "SecurityGroup for management console ingress"
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
 }
 
-# IAM Role for Lambda Authorizer
-resource "aws_iam_role" "iam_for_lambda_auth" {
-  name = "iam_for_lambda_auth"
-  inline_policy {
-    name   = "unity-cs-lambda-auth-inline-policy"
-    policy = data.aws_iam_policy_document.inline_policy.json
-  }
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
+resource "aws_vpc_security_group_ingress_rule" "mc_ingress_rule" {
+  count                        = length(data.aws_security_groups.mc_sg.ids) > 0 ? 1 : 0
+  security_group_id            = aws_security_group.mc_ingress_sg.id
+  description                  = "SecurityGroup ingress rule for management console"
+  ip_protocol                  = -1
+  referenced_security_group_id = data.aws_security_groups.mc_sg.ids[0]
 }
 
-# Unity CS Common Auth Lambda
-resource "aws_lambda_function" "cs_common_lambda_auth" {
-  filename      = "ucs-common-lambda-auth.zip"
-  function_name = var.unity_cs_lambda_authorizer_function_name
-  role          = aws_iam_role.iam_for_lambda_auth.arn
-  handler       = "index.handler"
-  runtime       = "nodejs14.x"
-  depends_on = [null_resource.download_lambda_zip, aws_cloudwatch_log_group.cs_common_lambda_auth_log_group]
+# TODO: select default node group more intelligently, or remove concept altogether
+resource "aws_ssm_parameter" "node_group_default_name" {
+  name = "/unity/extensions/eks/${var.deployment_name}/nodeGroups/default/name"
+  type = "String"
+  # Get name of first nodegroup in nodegroup map variable
+  value = keys(var.nodegroups)[0]
+  # Get first nodegroup name from keys of node group variable and use it to
+  # value = split(":", aws_eks_node_group.node_groups[keys(var.node_groups)[0]].id)[0]
+}
 
-  environment {
-    variables = {
-      COGNITO_CLIENT_ID_LIST = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_client_id_list.value
-      COGNITO_USER_POOL_ID = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_pool_id.value
-      COGNITO_GROUPS_ALLOWED = data.aws_ssm_parameter.api_gateway_cs_lambda_authorizer_cognito_user_groups_list.value
+resource "aws_ssm_parameter" "eks_subnets" {
+  name  = "/unity/extensions/eks/${local.cluster_name}/networking/subnets/publicIds"
+  type  = "String"
+  value = join(",", local.subnet_map["private"])
+}
+
+resource "helm_release" "aws-load-balancer-controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.6.1"
+  namespace  = "kube-system"
+  set = [
+    {
+      name  = "clusterName"
+      value = module.eks.cluster_name
+    },
+    {
+      name  = "serviceAccount.create"
+      value = "false"
+    },
+    {
+      name  = "serviceAccount.name"
+      value = "aws-load-balancer-controller"
+    }
+  ]
+
+  depends_on = [module.eks.eks_managed_node_groups]
+}
+
+resource "kubernetes_service_account" "aws-load-balancer-controller-service-account" {
+  metadata {
+    name      = "aws-load-balancer-controller"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" : aws_iam_role.aws-load-balancer-controller-role.arn
+    }
+    labels = {
+      "app.kubernetes.io/component" : "controller"
+      "app.kubernetes.io/name" : "aws-load-balancer-controller"
     }
   }
 }
 
-# Unity CS Common Auth Lambda Authorizer (in API Gateway)
-resource "aws_api_gateway_authorizer" "unity_cs_common_authorizer" {
-  name                              = var.unity_cs_api_gateway_authorizer_name
-  rest_api_id                       = aws_api_gateway_rest_api.rest_api.id
-  authorizer_uri                    = aws_lambda_function.cs_common_lambda_auth.invoke_arn
-  authorizer_credentials            = aws_iam_role.iam_for_lambda_auth.arn
-  authorizer_result_ttl_in_seconds  = 0
-  identity_source                   = "method.request.header.Authorization"
-  depends_on = [aws_lambda_function.cs_common_lambda_auth, aws_api_gateway_rest_api.rest_api]
+# AwsLoadBalancerController Role and Policy from https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+resource "aws_iam_role" "aws-load-balancer-controller-role" {
+  name = "AwsLoadBalancerControllerRole-${local.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.openidc_provider_domain_name}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.openidc_provider_domain_name}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller",
+            "${local.openidc_provider_domain_name}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/zsmce-tenantOperator-AMI-APIG"
 }
 
-# API Gateway deployment
-resource "aws_api_gateway_deployment" "api-gateway-deployment" {
-  rest_api_id = aws_api_gateway_rest_api.rest_api.id
-  stage_name  = var.rest_api_stage
-  depends_on = [aws_api_gateway_integration.root_level_get_method_mock_integration]
+resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {
+  role       = aws_iam_role.aws-load-balancer-controller-role.name
+  policy_arn = data.aws_iam_policy.aws-managed-load-balancer-policy.arn
 }
 
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
+resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
+  name = "AwsLoadBalancerControllerPolicy-${local.cluster_name}"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateSecurityGroup"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : "CreateSecurityGroup"
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "elasticloadbalancing:CreateAction" : [
+              "CreateTargetGroup",
+              "CreateLoadBalancer"
+            ]
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ],
+        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:SetWebAcl",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}

--- a/terraform-shared-services-api-gateway_module/main.tf
+++ b/terraform-shared-services-api-gateway_module/main.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "inline_policy" {
 
 # The Policy for Permission Boundary
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+  name = "maap-spsdeploy"
 }
 
 # IAM Role for Lambda Authorizer

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -24,7 +24,7 @@ data "aws_ssm_parameter" "eks_ami_1_30" {
   name = "/smce/amis/aml2023-eks-1-30"
 }
 
-data "aws_iam_policy" "mcp_operator_policy" {
+data "aws_iam_policy" "smce_operator_policy" {
   name = "zsmce-tenantOperator-AMI-APIG"
 }
 

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -8,6 +8,10 @@ data "aws_ssm_parameter" "subnet_list" {
   name = "/unity/account/network/subnet_list"
 }
 
+data "aws_ssm_parameter" "eks_ami_1_33" {
+  name = "/smce/amis/aml2023-eks-1-33"
+}
+
 data "aws_ssm_parameter" "eks_ami_1_32" {
   name = "/smce/amis/aml2023-eks-1-32"
 }

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -21,15 +21,15 @@ data "aws_ssm_parameter" "eks_ami_1_30" {
 }
 
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "maap-spsdeploy"
+  name = "smce-tenantOperator-AMI-APIG"
 }
 
 data "aws_iam_policy" "ebs_csi_policy" {
-  name = "maap-spsdeploy"
+  name = "U-CS_Service_Policy"
 }
 
 data "aws_iam_policy" "aws-managed-load-balancer-policy" {
-  arn = "arn:aws:iam::aws:policy/maap-spsdeploy"
+  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
 }
 
 data "aws_ebs_default_kms_key" "current" {}

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -9,27 +9,27 @@ data "aws_ssm_parameter" "subnet_list" {
 }
 
 data "aws_ssm_parameter" "eks_ami_1_32" {
-  name = "/mcp/amis/aml2023-eks-1-32"
+  name = "/smce/amis/aml2023-eks-1-32"
 }
 
 data "aws_ssm_parameter" "eks_ami_1_31" {
-  name = "/mcp/amis/aml2-eks-1-31"
+  name = "/smce/amis/aml2023-eks-1-31"
 }
 
 data "aws_ssm_parameter" "eks_ami_1_30" {
-  name = "/unity/account/eks/amis/aml2-eks-1-30"
+  name = "/smce/amis/aml2023-eks-1-30"
 }
 
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+  name = "maap-spsdeploy"
 }
 
 data "aws_iam_policy" "ebs_csi_policy" {
-  name = "U-CS_Service_Policy"
+  name = "maap-spsdeploy"
 }
 
 data "aws_iam_policy" "aws-managed-load-balancer-policy" {
-  arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
+  arn = "arn:aws:iam::aws:policy/maap-spsdeploy"
 }
 
 data "aws_ebs_default_kms_key" "current" {}

--- a/terraform-unity-eks_module/data.tf
+++ b/terraform-unity-eks_module/data.tf
@@ -25,7 +25,7 @@ data "aws_ssm_parameter" "eks_ami_1_30" {
 }
 
 data "aws_iam_policy" "mcp_operator_policy" {
-  name = "smce-tenantOperator-AMI-APIG"
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "aws_iam_policy" "ebs_csi_policy" {

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -17,6 +17,7 @@ locals {
       max_size                   = ng.max_size != null ? ng.max_size : 10
       desired_size               = ng.desired_size != null ? ng.desired_size : 3
       ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
+      ami_type                   = "AL2023_x86_64_STANDARD"
       instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
       iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -3,10 +3,11 @@ locals {
   cluster_name = var.deployment_name
   subnet_map   = jsondecode(data.aws_ssm_parameter.subnet_list.value)
   ami_map = {
+    "1.33"    = data.aws_ssm_parameter.eks_ami_1_33.value
     "1.32"    = data.aws_ssm_parameter.eks_ami_1_32.value
     "1.31"    = data.aws_ssm_parameter.eks_ami_1_31.value
     "1.30"    = data.aws_ssm_parameter.eks_ami_1_30.value
-    "default" = "ami-0741828961a03a9db"
+    "default" = "ami-0fc0ea06df871b6d9"
   }
   mergednodegroups = { for name, ng in var.nodegroups :
     name => {

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -11,20 +11,28 @@ locals {
   }
   mergednodegroups = { for name, ng in var.nodegroups :
     name => {
-      use_name_prefix            = false
-      create_iam_role            = false
-      min_size                   = ng.min_size != null ? ng.min_size : 1
-      max_size                   = ng.max_size != null ? ng.max_size : 10
-      desired_size               = ng.desired_size != null ? ng.desired_size : 3
-      ami_id                     = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
-      ami_type                   = "AL2023_x86_64_STANDARD"
-      instance_types             = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-      capacity_type              = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
-      enable_bootstrap_user_data = true
-      pre_bootstrap_user_data    = <<-EOT
-            sudo sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf && sudo sysctl -p |true
-        EOT
+      use_name_prefix  = false
+      create_iam_role  = false
+      min_size         = ng.min_size != null ? ng.min_size : 1
+      max_size         = ng.max_size != null ? ng.max_size : 10
+      desired_size     = ng.desired_size != null ? ng.desired_size : 3
+      ami_id           = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
+      ami_type         = "AL2023_x86_64_STANDARD"
+      instance_types   = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+      capacity_type    = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
+      iam_role_arn     = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
+      cloudinit_pre_nodeadm = [
+        {
+          content_type = "text/x-shellscript"
+          content      = <<-EOT
+            #!/bin/bash
+            set -e
+            # Enable IP forwarding for networking
+            sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf
+            sysctl -p || true
+          EOT
+        }
+      ]
       metadata_options = {
         "http_endpoint" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_endpoint", null) : null
         "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -20,19 +20,15 @@ locals {
       ami_type         = "AL2023_x86_64_STANDARD"
       instance_types   = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type    = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn     = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
-      cloudinit_pre_nodeadm = [
-        {
-          content_type = "text/x-shellscript"
-          content      = <<-EOT
-            #!/bin/bash
-            set -e
-            # Enable IP forwarding for networking
-            sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf
-            sysctl -p || true
-          EOT
-        }
-      ]
+      iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
+      enable_bootstrap_user_data = false
+      pre_bootstrap_user_data    = <<-EOT
+        #!/bin/bash
+        set -e
+        # Enable IP forwarding for networking
+        sed -i 's/^net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf
+        sysctl -p || true
+      EOT
       metadata_options = {
         "http_endpoint" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_endpoint", null) : null
         "http_put_response_hop_limit" : ng.metadata_options != null ? lookup(ng.metadata_options, "http_put_response_hop_limit", null) : null

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -19,7 +19,7 @@ locals {
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type  = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn   = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
+      iam_role_arn   = ng.iam_role_arn != null ? ng.iam_role_arn : data.aws_iam_role.cluster_iam_role.arn
       enable_bootstrap_user_data = false
       pre_bootstrap_user_data    = <<-EOT
         #!/bin/bash

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -13,14 +13,13 @@ locals {
     name => {
       use_name_prefix  = false
       create_iam_role  = false
-      min_size         = ng.min_size != null ? ng.min_size : 1
-      max_size         = ng.max_size != null ? ng.max_size : 10
-      desired_size     = ng.desired_size != null ? ng.desired_size : 3
-      ami_id           = ng.ami_id != null ? ng.ami_id : lookup(local.ami_map, var.cluster_version, local.ami_map["default"])
-      ami_type         = "AL2023_x86_64_STANDARD"
-      instance_types   = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-      capacity_type    = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn               = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
+      min_size       = ng.min_size != null ? ng.min_size : 1
+      max_size       = ng.max_size != null ? ng.max_size : 10
+      desired_size   = ng.desired_size != null ? ng.desired_size : 3
+      ami_type       = "AL2023_x86_64_STANDARD"
+      instance_types = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+      capacity_type  = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
+      iam_role_arn   = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
       enable_bootstrap_user_data = false
       pre_bootstrap_user_data    = <<-EOT
         #!/bin/bash

--- a/terraform-unity-eks_module/locals.tf
+++ b/terraform-unity-eks_module/locals.tf
@@ -19,7 +19,7 @@ locals {
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ng.instance_types != null ? ng.instance_types : ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
       capacity_type  = ng.capacity_type != null ? ng.capacity_type : "ON_DEMAND"
-      iam_role_arn   = ng.iam_role_arn != null ? ng.iam_role_arn : data.aws_iam_role.cluster_iam_role.arn
+      iam_role_arn   = ng.iam_role_arn != null ? ng.iam_role_arn : aws_iam_role.cluster_iam_role.arn
       enable_bootstrap_user_data = false
       pre_bootstrap_user_data    = <<-EOT
         #!/bin/bash

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -435,15 +435,15 @@ resource "helm_release" "aws-load-balancer-controller" {
   chart      = "aws-load-balancer-controller"
   version    = "1.6.1"
   namespace  = "kube-system"
-  set {
+  set = {
     name  = "clusterName"
     value = module.eks.cluster_name
   }
-  set {
+  set = {
     name  = "serviceAccount.create"
     value = "false"
   }
-  set {
+  set = {
     name  = "serviceAccount.name"
     value = "aws-load-balancer-controller"
   }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -375,7 +375,7 @@ module "eks" {
 }
 
 resource "aws_launch_template" "node_group_launch_template" {
-  image_id = "ami-0e3e9697a56f6ba66"
+  image_id = "ami-0fc0ea06df871b6d9"
   name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
   user_data = base64encode(<<EOT
 #!/bin/bash

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -435,15 +435,15 @@ resource "helm_release" "aws-load-balancer-controller" {
   chart      = "aws-load-balancer-controller"
   version    = "1.6.1"
   namespace  = "kube-system"
-  set = {
+  set {
     name  = "clusterName"
     value = module.eks.cluster_name
   }
-  set = {
+  set {
     name  = "serviceAccount.create"
     value = "false"
   }
-  set = {
+  set {
     name  = "serviceAccount.name"
     value = "aws-load-balancer-controller"
   }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -1,321 +1,48 @@
-resource "aws_iam_role" "cluster_iam_role" {
+# Use existing IAM role instead of creating new one
+data "aws_iam_role" "cluster_iam_role" {
   name = "${local.cluster_name}-eks-node-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "eks.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "ec2.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "s3.amazonaws.com" # or the appropriate AWS service
-        },
-      },
-    ],
-  })
-
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
-
 }
 
-resource "aws_iam_role_policy_attachment" "container-reg" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
+# Policy attachments commented out - role already has policies attached manually
+# resource "aws_iam_role_policy_attachment" "container-reg" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+# }
 
-resource "aws_iam_role_policy_attachment" "ebscsi" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-}
-resource "aws_iam_role_policy_attachment" "eks-cni" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-}
-resource "aws_iam_role_policy_attachment" "worker-node" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-}
-resource "aws_iam_role_policy_attachment" "ssm-automation" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
-}
-resource "aws_iam_role_policy_attachment" "ssm-managed-instance" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
-}
+# resource "aws_iam_role_policy_attachment" "ebscsi" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+# }
+# resource "aws_iam_role_policy_attachment" "eks-cni" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+# }
+# resource "aws_iam_role_policy_attachment" "worker-node" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+# }
+# resource "aws_iam_role_policy_attachment" "ssm-automation" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
+# }
+# resource "aws_iam_role_policy_attachment" "ssm-managed-instance" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+# }
+# resource "aws_iam_role_policy_attachment" "cloudwatch-agent" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+# }
 
 
-resource "aws_iam_role_policy_attachment" "node-policy" {
-  role       = aws_iam_role.cluster_iam_role.name
-  policy_arn = aws_iam_policy.custom_policy.arn
-}
+# resource "aws_iam_role_policy_attachment" "node-policy" {
+#   role       = data.aws_iam_role.cluster_iam_role.name
+#   policy_arn = data.aws_iam_policy.custom_policy.arn
+# }
 
-resource "aws_iam_policy" "custom_policy" {
-  name        = "${local.cluster_name}-eks-policy" # Give a unique name to your policy
-  path        = "/"                                # Optionally, specify a path for the policy
-  description = "A custom policy that provides access to EC2, ECR, SNS, etc."
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": "ec2:CreateTags",
-            "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": [
-                        "CreateVolume",
-                        "CreateSnapshot"
-                    ]
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor1",
-            "Effect": "Allow",
-            "Action": "ec2:CreateVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor2",
-            "Effect": "Allow",
-            "Action": "ec2:CreateVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "aws:RequestTag/CSIVolumeName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor3",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor4",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/CSIVolumeName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor5",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteVolume",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor6",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteSnapshot",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor7",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteSnapshot",
-            "Resource": "*",
-            "Condition": {
-                "StringLike": {
-                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
-                }
-            }
-        },
-        {
-            "Sid": "VisualEditor8",
-            "Effect": "Allow",
-            "Action": "ec2:CreateTags",
-            "Resource": "arn:aws:ec2:*:*:network-interface/*"
-        },
-        {
-            "Sid": "VisualEditor9",
-            "Effect": "Allow",
-            "Action": "ec2:DeleteTags",
-            "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
-            ]
-        },
-        {
-            "Sid": "VisualEditor10",
-            "Effect": "Allow",
-            "Action": [
-                "sns:Publish",
-                "lambda:InvokeFunction",
-                "ssm:GetParameter"
-            ],
-            "Resource": [
-                "arn:aws:lambda:*:*:function:Automation*",
-                "arn:aws:sns:*:*:Automation*",
-                "arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:GetAuthorizationToken",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:GetRepositoryPolicy",
-                "ecr:DescribeRepositories",
-                "ecr:ListImages",
-                "ecr:DescribeImages",
-                "ecr:BatchGetImage",
-                "ecr:GetLifecyclePolicy",
-                "ecr:GetLifecyclePolicyPreview",
-                "ecr:ListTagsForResource",
-                "ecr:DescribeImageScanFindings"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "VisualEditor11",
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeInstances",
-                "cloudwatch:PutMetricData",
-                "ec2:DescribeVolumesModifications",
-                "ec2:CreateImage",
-                "ec2:CopyImage",
-                "ssm:ListInstanceAssociations",
-                "ec2:DescribeSnapshots",
-                "ssm:GetParameter",
-                "ssm:UpdateAssociationStatus",
-                "logs:CreateLogStream",
-                "cloudformation:DescribeStackEvents",
-                "ec2:StartInstances",
-                "ssm:UpdateInstanceInformation",
-                "ec2:DescribeVolumes",
-                "cloudformation:UpdateStack",
-                "ec2:UnassignPrivateIpAddresses",
-                "ec2:DescribeRouteTables",
-                "ssm:PutComplianceItems",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetLifecyclePolicy",
-                "ec2:DetachVolume",
-                "sns:*",
-                "ec2:ModifyVolume",
-                "ecr:DescribeImageScanFindings",
-                "ec2:CreateTags",
-                "ec2:ModifyNetworkInterfaceAttribute",
-                "ecr:GetDownloadUrlForLayer",
-                "ec2:DeleteNetworkInterface",
-                "ec2messages:AcknowledgeMessage",
-                "ec2:RunInstances",
-                "ecr:GetAuthorizationToken",
-                "ssm:GetParameters",
-                "ec2:StopInstances",
-                "s3-object-lambda:*",
-                "ec2:AssignPrivateIpAddresses",
-                "logs:CreateLogGroup",
-                "cloudformation:DescribeStacks",
-                "ec2:CreateNetworkInterface",
-                "cloudformation:DeleteStack",
-                "ec2:DescribeInstanceTypes",
-                "ecr:BatchGetImage",
-                "ecr:DescribeImages",
-                "ec2messages:SendReply",
-                "eks:DescribeCluster",
-                "ec2:DescribeSubnets",
-                "ec2:AttachVolume",
-                "ec2:DeregisterImage",
-                "ec2:DeleteSnapshot",
-                "ssm:DescribeDocument",
-                "ec2:DeleteTags",
-                "ec2messages:GetEndpoint",
-                "logs:DescribeLogStreams",
-                "ssmmessages:OpenControlChannel",
-                "ec2messages:GetMessages",
-                "ecr:ListTagsForResource",
-                "ssm:PutConfigurePackageResult",
-                "ecr:ListImages",
-                "ssm:GetManifest",
-                "ec2messages:DeleteMessage",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2messages:FailMessage",
-                "ec2:DescribeAvailabilityZones",
-                "ssmmessages:OpenDataChannel",
-                "ec2:CreateSnapshot",
-                "ssm:GetDocument",
-                "ecr:DescribeRepositories",
-                "ec2:DescribeInstanceStatus",
-                "ssm:DescribeAssociation",
-                "ec2:TerminateInstances",
-                "ec2:DetachNetworkInterface",
-                "logs:DescribeLogGroups",
-                "ssm:GetDeployablePatchSnapshotForInstance",
-                "s3:*",
-                "ec2:DescribeTags",
-                "ecr:GetLifecyclePolicyPreview",
-                "ssmmessages:CreateControlChannel",
-                "logs:PutLogEvents",
-                "ec2:DescribeSecurityGroups",
-                "ssmmessages:CreateDataChannel",
-                "ec2:DescribeImages",
-                "ssm:PutInventory",
-                "cloudformation:CreateStack",
-                "ec2:DescribeVpcs",
-                "ssm:*",
-                "ec2:AttachNetworkInterface",
-                "ssm:ListAssociations",
-                "ssm:UpdateInstanceAssociationStatus",
-                "ecr:GetRepositoryPolicy"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
+# Use existing IAM policy instead of creating new one
+data "aws_iam_policy" "custom_policy" {
+  name = "${local.cluster_name}-eks-policy"
 }
 
 module "eks" {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -466,7 +466,7 @@ resource "aws_iam_role" "aws-load-balancer-controller-role" {
   })
 
   managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/smce-tenantOperator-AMI-APIG"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/zsmce-tenantOperator-AMI-APIG"
 }
 
 resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -435,18 +435,20 @@ resource "helm_release" "aws-load-balancer-controller" {
   chart      = "aws-load-balancer-controller"
   version    = "1.6.1"
   namespace  = "kube-system"
-  set {
-    name  = "clusterName"
-    value = module.eks.cluster_name
-  }
-  set {
-    name  = "serviceAccount.create"
-    value = "false"
-  }
-  set {
-    name  = "serviceAccount.name"
-    value = "aws-load-balancer-controller"
-  }
+  set = [
+    {
+      name  = "clusterName"
+      value = module.eks.cluster_name
+    },
+    {
+      name  = "serviceAccount.create"
+      value = "false"
+    },
+    {
+      name  = "serviceAccount.name"
+      value = "aws-load-balancer-controller"
+    }
+  ]
 
   depends_on = [module.eks.eks_managed_node_groups]
 }

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -85,12 +85,12 @@ module "eks" {
   cluster_additional_security_group_ids = [aws_security_group.mc_ingress_sg.id]
   create_iam_role                       = false
   enable_irsa                           = true
-  iam_role_arn                          = aws_iam_role.cluster_iam_role.arn
+  iam_role_arn                          = data.aws_iam_role.cluster_iam_role.arn
   #node_security_group_id = data.aws_ssm_parameter.node_sg.value
 
   eks_managed_node_group_defaults = {
     instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-    iam_role_arn   = aws_iam_role.cluster_iam_role.arn
+    iam_role_arn   = data.aws_iam_role.cluster_iam_role.arn
   }
 
   eks_managed_node_groups = local.mergednodegroups

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -491,7 +491,7 @@ resource "aws_iam_role" "aws-load-balancer-controller-role" {
   })
 
   managed_policy_arns  = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/smce-tenantOperator-AMI-APIG"
 }
 
 resource "aws_iam_role_policy_attachment" "aws-load-balancer-policy-attachment" {

--- a/terraform-unity-eks_module/main.tf
+++ b/terraform-unity-eks_module/main.tf
@@ -374,25 +374,6 @@ module "eks" {
   tags                            = var.tags
 }
 
-resource "aws_launch_template" "node_group_launch_template" {
-  image_id = "ami-0fc0ea06df871b6d9"
-  name     = "eks-${local.cluster_name}-nodeGroup-launchTemplate"
-  user_data = base64encode(<<EOT
-#!/bin/bash
-set -o xtrace
-/etc/eks/bootstrap.sh ${local.cluster_name}
-  EOT
-  )
-  tag_specifications {
-    resource_type = "instance"
-    tags = merge(local.common_tags, {
-      Name      = "${local.cluster_name} Node Group Node"
-      Component = "EKS EC2 Instance"
-      Stack     = "EKS EC2 Instance"
-    })
-  }
-}
-
 resource "aws_security_group" "mc_ingress_sg" {
   name        = "${var.project}-${var.venue}-mc-ingress-sg"
   description = "SecurityGroup for management console ingress"
@@ -408,12 +389,6 @@ resource "aws_vpc_security_group_ingress_rule" "mc_ingress_rule" {
 }
 
 # TODO: select default node group more intelligently, or remove concept altogether
-resource "aws_ssm_parameter" "node_group_default_launch_template_name" {
-  name  = "/unity/extensions/eks/${local.cluster_name}/nodeGroups/default/launchTemplateName"
-  type  = "String"
-  value = aws_launch_template.node_group_launch_template.name
-}
-
 resource "aws_ssm_parameter" "node_group_default_name" {
   name = "/unity/extensions/eks/${var.deployment_name}/nodeGroups/default/name"
   type = "String"

--- a/terraform-unity-eks_module/outputs.tf
+++ b/terraform-unity-eks_module/outputs.tf
@@ -5,5 +5,5 @@ output "eks" {
 
 output "cluster_iam_role" {
   description = "ARN of cluster iam role"
-  value       = aws_iam_role.cluster_iam_role.name
+  value       = data.aws_iam_role.cluster_iam_role.name
 }

--- a/terraform-unity-eks_module/outputs.tf
+++ b/terraform-unity-eks_module/outputs.tf
@@ -5,5 +5,5 @@ output "eks" {
 
 output "cluster_iam_role" {
   description = "ARN of cluster iam role"
-  value       = data.aws_iam_role.cluster_iam_role.name
+  value       = aws_iam_role.cluster_iam_role.name
 }

--- a/terraform-unity-eks_module/provider.tf
+++ b/terraform-unity-eks_module/provider.tf
@@ -1,5 +1,5 @@
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     exec {

--- a/terraform-unity-eks_module/provider.tf
+++ b/terraform-unity-eks_module/provider.tf
@@ -1,8 +1,8 @@
 provider "helm" {
-  kubernetes = {
+  kubernetes {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec = {
+    exec {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
@@ -15,7 +15,7 @@ provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
-  exec = {
+  exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed

--- a/terraform-unity-eks_module/provider.tf
+++ b/terraform-unity-eks_module/provider.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
@@ -15,7 +15,7 @@ provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
-  exec {
+  exec = {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed

--- a/terraform-unity-eks_module/provider.tf
+++ b/terraform-unity-eks_module/provider.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -20,7 +20,6 @@ variable "nodegroups" {
     desired_size               = optional(number)
     instance_types             = optional(list(string))
     capacity_type              = optional(string)
-    enable_bootstrap_user_data = optional(bool)
     metadata_options           = optional(map(any))
     block_device_mappings = optional(map(object({
       device_name = string

--- a/terraform-unity-eks_module/variables.tf
+++ b/terraform-unity-eks_module/variables.tf
@@ -55,7 +55,7 @@ variable "aws_auth_roles" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.31"
+  default = "1.33"
 }
 
 variable "project" {

--- a/terraform-unity/main.mcp.tf
+++ b/terraform-unity/main.mcp.tf
@@ -10,7 +10,7 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
-  default_tags {
+  default_tags = {
     tags = merge(
       var.default_tags,
       {

--- a/terraform-unity/variables.jpl.tf
+++ b/terraform-unity/variables.jpl.tf
@@ -3,7 +3,7 @@
 #variable "ami_key_pair_name" { default = "barber-unity-pair" }
 
 variable "ami_name" { default = "unity-ubuntu" }
-variable "ami_id" { default = "ami-0688ba7eeeeefe3cd" }
+variable "ami_id" { default = "ami-00f46ccd1cbfb363e" }
 #variable "ami_id" { default = "ami-04505e74c0741db8d" }
 variable "ami_key_pair_name" { default = "unity-cs-smolensk" }
 variable "vpc_id" { default = "vpc-0fd177185e450d73d" }


### PR DESCRIPTION
## Purpose
Transitioned to SPS being deployed on SMCE since MCP has been decommissioned 
## Proposed Changes
- [CHANGE] MCP to SMCE 
- [CHANGE] Had to make some syntax changes for this to compile
- [FIX] Bootstrapping methods not allowed by AL2023 
- [REMOVE] Using custom templates because that was unnecessarily complex
## Issues
Relevant issue: https://github.com/unity-sds/unity-sps/issues/453
## Testing
Tested SPS airflow instance which was using SMCE resources  
